### PR TITLE
Add live next-token learning support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,5 +8,5 @@
 # Course API Contract
 
 - Use the tests from the [AI Testers API course repository](https://github.com/AI-Testers-pl/ait2api1-api-ai) as the compatibility feedback loop for `https://awesome.byst.re`.
-- After backend changes, run the suite from the [latest available lesson (`l12` currently)](https://github.com/AI-Testers-pl/ait2api1-api-ai/tree/master/l12) and keep it green (`cd l12 && npm ci && npm test`).
+- After awesome-localstack deployments, run the suite from the [latest available lesson (`l12` currently)](https://github.com/AI-Testers-pl/ait2api1-api-ai/tree/master/l12) and keep it green (`cd l12 && npm ci && npm test`).
 - The lesson tests define the required course contract. Endpoints and behavior not covered by that suite may change; covered behavior must remain compatible.

--- a/src/main/java/com/awesome/testing/config/OllamaProperties.java
+++ b/src/main/java/com/awesome/testing/config/OllamaProperties.java
@@ -10,5 +10,6 @@ import org.springframework.validation.annotation.Validated;
 public class OllamaProperties {
 
     private String baseUrl;
+    private int maxToolCallIterations = 8;
 
-} 
+}

--- a/src/main/java/com/awesome/testing/controller/OllamaController.java
+++ b/src/main/java/com/awesome/testing/controller/OllamaController.java
@@ -4,11 +4,14 @@ import com.awesome.testing.dto.ollama.ChatRequestDto;
 import com.awesome.testing.dto.ollama.ChatResponseDto;
 import com.awesome.testing.dto.ollama.GenerateResponseDto;
 import com.awesome.testing.dto.ollama.ModelNotFoundDto;
+import com.awesome.testing.dto.ollama.LearningNextTokenRequestDto;
+import com.awesome.testing.dto.ollama.LearningNextTokenResponseDto;
 import com.awesome.testing.dto.ollama.OllamaToolDefinitionDto;
 import com.awesome.testing.dto.ollama.StreamedRequestDto;
 import com.awesome.testing.security.CustomPrincipal;
 import com.awesome.testing.security.ratelimit.AuthRateLimitGuard;
 import com.awesome.testing.service.ollama.OllamaFunctionCallingService;
+import com.awesome.testing.service.ollama.OllamaLearningService;
 import com.awesome.testing.service.ollama.OllamaService;
 import com.awesome.testing.service.ollama.OllamaToolDefinitionCatalog;
 import com.awesome.testing.service.prompt.PromptInjector;
@@ -44,10 +47,26 @@ import java.util.List;
 public class OllamaController {
 
     private final OllamaService ollamaService;
+    private final OllamaLearningService ollamaLearningService;
     private final OllamaFunctionCallingService functionCallingService;
     private final OllamaToolDefinitionCatalog toolDefinitionCatalog;
     private final PromptInjector promptInjector;
     private final AuthRateLimitGuard authRateLimitGuard;
+
+    @Operation(summary = "Inspect live next-token probabilities",
+            description = "Runs one raw Ollama generation step and returns a stable, ranked top-logprob teaching response.")
+    @ApiResponse(responseCode = "200", description = "Next-token candidates returned successfully")
+    @ApiResponse(responseCode = "400", description = "Invalid request")
+    @ApiResponse(responseCode = "422", description = "The selected model or runtime did not expose logprobs")
+    @ApiResponse(responseCode = "429", description = "Too many requests")
+    @PostMapping(value = "/learning/next-token", produces = MediaType.APPLICATION_JSON_VALUE)
+    public LearningNextTokenResponseDto nextTokenDistribution(
+            HttpServletRequest servletRequest,
+            @AuthenticationPrincipal CustomPrincipal principal,
+            @Valid @RequestBody LearningNextTokenRequestDto request) {
+        authRateLimitGuard.checkOllama(servletRequest, principal != null ? principal.getUsername() : null);
+        return ollamaLearningService.nextTokenDistribution(request).block();
+    }
 
     @Operation(summary = "Generate text using Ollama model",
             description = "Streams generated text chunks from the configured Ollama backend for a single prompt.")

--- a/src/main/java/com/awesome/testing/dto/ollama/LearningNextTokenCandidateDto.java
+++ b/src/main/java/com/awesome/testing/dto/ollama/LearningNextTokenCandidateDto.java
@@ -1,0 +1,18 @@
+package com.awesome.testing.dto.ollama;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LearningNextTokenCandidateDto {
+    private String token;
+    private int rank;
+    private double logprob;
+    private double probability;
+    private double normalizedProbability;
+}

--- a/src/main/java/com/awesome/testing/dto/ollama/LearningNextTokenRequestDto.java
+++ b/src/main/java/com/awesome/testing/dto/ollama/LearningNextTokenRequestDto.java
@@ -1,0 +1,36 @@
+package com.awesome.testing.dto.ollama;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LearningNextTokenRequestDto {
+
+    @NotBlank
+    @Size(max = 200)
+    @Schema(description = "Installed Ollama model to inspect", example = "llama3.2:1b")
+    private String model;
+
+    @NotBlank
+    @Size(max = 2000)
+    @Schema(description = "Raw prompt whose next-token distribution should be inspected")
+    private String prompt;
+
+    @NotNull
+    @Min(2)
+    @Max(20)
+    @Builder.Default
+    @Schema(description = "Number of candidate tokens requested from Ollama", defaultValue = "10")
+    private Integer topK = 10;
+}

--- a/src/main/java/com/awesome/testing/dto/ollama/LearningNextTokenResponseDto.java
+++ b/src/main/java/com/awesome/testing/dto/ollama/LearningNextTokenResponseDto.java
@@ -1,0 +1,22 @@
+package com.awesome.testing.dto.ollama;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LearningNextTokenResponseDto {
+    private String source;
+    private String modelLabel;
+    private String prompt;
+    private String generatedToken;
+    private double capturedProbabilityMass;
+    private boolean truncated;
+    private List<LearningNextTokenCandidateDto> candidates;
+}

--- a/src/main/java/com/awesome/testing/service/ollama/OllamaFunctionCallingService.java
+++ b/src/main/java/com/awesome/testing/service/ollama/OllamaFunctionCallingService.java
@@ -1,5 +1,6 @@
 package com.awesome.testing.service.ollama;
 
+import com.awesome.testing.config.OllamaProperties;
 import com.awesome.testing.dto.ollama.ChatMessageDto;
 import com.awesome.testing.dto.ollama.ChatRequestDto;
 import com.awesome.testing.dto.ollama.ChatResponseDto;
@@ -23,10 +24,9 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public class OllamaFunctionCallingService {
 
-    private static final int MAX_TOOL_CALL_ITERATIONS = 3;
-
     private final WebClient ollamaWebClient;
     private final OllamaToolRegistry toolRegistry;
+    private final OllamaProperties ollamaProperties;
 
     public Flux<ChatResponseDto> chatWithTools(ChatRequestDto request) {
         if (request.getTools() == null || request.getTools().isEmpty()) {
@@ -44,8 +44,9 @@ public class OllamaFunctionCallingService {
                                                 List<ChatMessageDto> history,
                                                 int iteration,
                                                 OllamaRequestHandler ctx) {
-        if (iteration >= MAX_TOOL_CALL_ITERATIONS) {
-            log.error("Exceeded maximum tool call iterations ({}) for model {}", MAX_TOOL_CALL_ITERATIONS, baseRequest.getModel());
+        int maxIterations = ollamaProperties.getMaxToolCallIterations();
+        if (iteration >= maxIterations) {
+            log.error("Exceeded maximum tool call iterations ({}) for model {}", maxIterations, baseRequest.getModel());
             return Flux.error(new IllegalStateException("Exceeded maximum tool call iterations"));
         }
 

--- a/src/main/java/com/awesome/testing/service/ollama/OllamaLearningService.java
+++ b/src/main/java/com/awesome/testing/service/ollama/OllamaLearningService.java
@@ -1,0 +1,147 @@
+package com.awesome.testing.service.ollama;
+
+import com.awesome.testing.controller.exception.CustomException;
+import com.awesome.testing.dto.ollama.LearningNextTokenCandidateDto;
+import com.awesome.testing.dto.ollama.LearningNextTokenRequestDto;
+import com.awesome.testing.dto.ollama.LearningNextTokenResponseDto;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class OllamaLearningService {
+
+    private static final String SOURCE = "ollama-live";
+    private static final double COMPLETE_MASS_THRESHOLD = 0.999999d;
+
+    private final WebClient ollamaWebClient;
+    private final ObjectMapper objectMapper;
+
+    public Mono<LearningNextTokenResponseDto> nextTokenDistribution(LearningNextTokenRequestDto request) {
+        Map<String, Object> upstreamRequest = Map.of(
+                "model", request.getModel(),
+                "prompt", request.getPrompt(),
+                "stream", false,
+                "raw", true,
+                "think", false,
+                "logprobs", true,
+                "top_logprobs", request.getTopK(),
+                "options", Map.of(
+                        "temperature", 1,
+                        "num_predict", 1
+                )
+        );
+
+        return ollamaWebClient.post()
+                .uri("/api/generate")
+                .bodyValue(upstreamRequest)
+                .retrieve()
+                .bodyToMono(String.class)
+                .switchIfEmpty(Mono.error(unsupportedLogprobs()))
+                .map(this::readResponse)
+                .map(response -> parseResponse(request, response));
+    }
+
+    private JsonNode readResponse(String responseBody) {
+        try {
+            return objectMapper.readTree(responseBody);
+        } catch (JacksonException exception) {
+            throw new CustomException("Ollama returned an invalid JSON response", HttpStatus.BAD_GATEWAY, exception);
+        }
+    }
+
+    LearningNextTokenResponseDto parseResponse(LearningNextTokenRequestDto request, JsonNode response) {
+        JsonNode logprobs = response.path("logprobs");
+        if (!logprobs.isArray() || logprobs.size() == 0) {
+            throw unsupportedLogprobs();
+        }
+
+        JsonNode firstPosition = logprobs.get(0);
+        String generatedToken = firstPosition.path("token").asString(response.path("response").asString(""));
+        Map<String, Double> tokenLogprobs = new LinkedHashMap<>();
+
+        JsonNode topLogprobs = firstPosition.path("top_logprobs");
+        if (topLogprobs.isArray()) {
+            topLogprobs.forEach(candidate -> addCandidate(tokenLogprobs, candidate));
+        }
+        addCandidate(tokenLogprobs, firstPosition);
+
+        List<Map.Entry<String, Double>> validCandidates = tokenLogprobs.entrySet().stream()
+                .filter(entry -> Double.isFinite(entry.getValue()))
+                .sorted(Map.Entry.<String, Double>comparingByValue(Comparator.reverseOrder()))
+                .limit(request.getTopK())
+                .toList();
+
+        if (validCandidates.isEmpty()) {
+            throw unsupportedLogprobs();
+        }
+
+        List<Double> rawProbabilities = validCandidates.stream()
+                .map(entry -> Math.exp(entry.getValue()))
+                .toList();
+        double mass = rawProbabilities.stream()
+                .filter(Double::isFinite)
+                .mapToDouble(Double::doubleValue)
+                .sum();
+        if (!Double.isFinite(mass) || mass <= 0d) {
+            throw unsupportedLogprobs();
+        }
+
+        List<LearningNextTokenCandidateDto> candidates = new ArrayList<>(validCandidates.size());
+        for (int index = 0; index < validCandidates.size(); index++) {
+            Map.Entry<String, Double> candidate = validCandidates.get(index);
+            double probability = rawProbabilities.get(index);
+            candidates.add(LearningNextTokenCandidateDto.builder()
+                    .token(candidate.getKey())
+                    .rank(index + 1)
+                    .logprob(candidate.getValue())
+                    .probability(probability)
+                    .normalizedProbability(probability / mass)
+                    .build());
+        }
+
+        double displayMass = Math.min(Math.max(mass, 0d), 1d);
+        return LearningNextTokenResponseDto.builder()
+                .source(SOURCE)
+                .modelLabel(response.path("model").asString(request.getModel()))
+                .prompt(request.getPrompt())
+                .generatedToken(generatedToken)
+                .capturedProbabilityMass(displayMass)
+                .truncated(displayMass < COMPLETE_MASS_THRESHOLD)
+                .candidates(candidates)
+                .build();
+    }
+
+    private static void addCandidate(Map<String, Double> tokenLogprobs, JsonNode candidate) {
+        JsonNode tokenNode = candidate.get("token");
+        JsonNode logprobNode = candidate.get("logprob");
+        if (tokenNode == null || !tokenNode.isString() || logprobNode == null || !logprobNode.isNumber()) {
+            return;
+        }
+
+        double logprob = logprobNode.doubleValue();
+        if (!Double.isFinite(logprob)) {
+            return;
+        }
+        tokenLogprobs.merge(tokenNode.stringValue(), logprob, Math::max);
+    }
+
+    private static CustomException unsupportedLogprobs() {
+        return new CustomException(
+                "The selected model or Ollama runtime did not return next-token log probabilities",
+                HttpStatus.UNPROCESSABLE_CONTENT
+        );
+    }
+}

--- a/src/main/java/com/awesome/testing/service/ollama/OllamaToolDefinitionCatalog.java
+++ b/src/main/java/com/awesome/testing/service/ollama/OllamaToolDefinitionCatalog.java
@@ -66,7 +66,7 @@ public class OllamaToolDefinitionCatalog {
                                 .properties(Map.of(
                                         "offset", property("integer", "Zero-based offset into the catalog (default 0)."),
                                         "limit", property("integer", "Number of products to fetch (default 25, max 100)."),
-                                        "category", property("string", "Case-insensitive category filter, e.g., 'electronics'."),
+                                        "category", property("string", "Plain case-insensitive category name, e.g., 'electronics'. Never include XML or <parameter> markup in this value."),
                                         "inStockOnly", property("boolean", "If true, only return products with stockQuantity > 0.")
                                 ))
                                 .build())

--- a/src/main/java/com/awesome/testing/service/ollama/function/ProductCatalogFunctionHandler.java
+++ b/src/main/java/com/awesome/testing/service/ollama/function/ProductCatalogFunctionHandler.java
@@ -11,6 +11,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Slf4j
 @Component
@@ -18,6 +20,9 @@ import java.util.Map;
 public class ProductCatalogFunctionHandler implements FunctionCallHandler {
 
     static final String TOOL_NAME = "list_products";
+    private static final Pattern LEAKED_IN_STOCK_ARGUMENT = Pattern.compile(
+            "^\\s*([^<>]*?)\\s*</parameter>\\s*<parameter=inStockOnly>\\s*(true|false)\\s*(?:</parameter>)?\\s*$",
+            Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
     private final ProductService productService;
     private final ObjectMapper objectMapper;
@@ -33,10 +38,13 @@ public class ProductCatalogFunctionHandler implements FunctionCallHandler {
             Map<String, Object> args = toolCall.getFunction().getArguments();
             int offset = parseInt(args != null ? args.get("offset") : null, 0);
             int limit = parseInt(args != null ? args.get("limit") : null, 25);
-            String category = parseCategory(args != null ? args.get("category") : null);
-            Boolean inStockOnly = parseBoolean(args != null ? args.get("inStockOnly") : null);
+            ParsedCategory parsedCategory = parseCategory(args != null ? args.get("category") : null);
+            Boolean explicitInStockOnly = parseBoolean(args != null ? args.get("inStockOnly") : null);
+            Boolean inStockOnly = explicitInStockOnly != null
+                    ? explicitInStockOnly
+                    : parsedCategory.leakedInStockOnly();
 
-            ProductListDto list = productService.listProducts(offset, limit, category, inStockOnly);
+            ProductListDto list = productService.listProducts(offset, limit, parsedCategory.category(), inStockOnly);
             return ChatMessageDto.builder()
                     .role("tool")
                     .toolName(TOOL_NAME)
@@ -68,12 +76,28 @@ public class ProductCatalogFunctionHandler implements FunctionCallHandler {
         throw new IllegalArgumentException("Unsupported number format");
     }
 
-    private String parseCategory(Object value) {
+    private ParsedCategory parseCategory(Object value) {
         if (value == null) {
-            return null;
+            return new ParsedCategory(null, null);
         }
         String category = value.toString().trim();
-        return category.isBlank() ? null : category;
+        if (category.isBlank()) {
+            return new ParsedCategory(null, null);
+        }
+
+        Matcher leakedArgument = LEAKED_IN_STOCK_ARGUMENT.matcher(category);
+        if (leakedArgument.matches()) {
+            String repairedCategory = leakedArgument.group(1).trim();
+            Boolean repairedInStockOnly = Boolean.valueOf(leakedArgument.group(2));
+            log.warn("Repaired leaked tool markup in list_products category; category='{}', inStockOnly={}",
+                    repairedCategory, repairedInStockOnly);
+            return new ParsedCategory(repairedCategory.isBlank() ? null : repairedCategory, repairedInStockOnly);
+        }
+
+        if (category.contains("<") || category.contains(">")) {
+            throw new IllegalArgumentException("category must be a plain category name without tool markup");
+        }
+        return new ParsedCategory(category, null);
     }
 
     private Boolean parseBoolean(Object value) {
@@ -103,5 +127,8 @@ public class ProductCatalogFunctionHandler implements FunctionCallHandler {
                     .content("{\"error\":\"" + message + "\"}")
                     .build();
         }
+    }
+
+    private record ParsedCategory(String category, Boolean leakedInStockOnly) {
     }
 }

--- a/src/main/java/com/awesome/testing/service/prompt/PromptInjector.java
+++ b/src/main/java/com/awesome/testing/service/prompt/PromptInjector.java
@@ -32,10 +32,7 @@ public class PromptInjector {
         List<ChatMessageDto> cleanedHistory = stripExistingPrompts(original.getMessages(), chatPrompt, toolPrompt);
 
         List<ChatMessageDto> augmentedHistory = new ArrayList<>();
-        augmentedHistory.add(systemMessage(chatPrompt));
-        if (includeToolPrompt) {
-            augmentedHistory.add(systemMessage(toolPrompt));
-        }
+        augmentedHistory.add(systemMessage(mergePrompts(chatPrompt, toolPrompt)));
         augmentedHistory.addAll(cleanedHistory);
 
         return ChatRequestDto.builder()
@@ -47,6 +44,16 @@ public class PromptInjector {
                 .keepAlive(original.getKeepAlive())
                 .think(original.getThink())
                 .build();
+    }
+
+    private static String mergePrompts(String chatPrompt, String toolPrompt) {
+        if (toolPrompt == null || toolPrompt.isBlank()) {
+            return chatPrompt;
+        }
+        if (chatPrompt == null || chatPrompt.isBlank()) {
+            return toolPrompt;
+        }
+        return chatPrompt.strip() + "\n\n" + toolPrompt.strip();
     }
 
     private static List<ChatMessageDto> stripExistingPrompts(List<ChatMessageDto> history,

--- a/src/test/java/com/awesome/testing/endpoints/ollama/OllamaChatControllerTest.java
+++ b/src/test/java/com/awesome/testing/endpoints/ollama/OllamaChatControllerTest.java
@@ -263,8 +263,8 @@ class OllamaChatControllerTest extends AbstractOllamaTest {
         verify(postRequestedFor(urlEqualTo("/api/chat"))
                 .withRequestBody(matchingJsonPath("$.tools[0].function.name", equalTo("get_product_snapshot")))
                 .withRequestBody(matchingJsonPath("$.messages[0].role", equalTo("system")))
-                .withRequestBody(matchingJsonPath("$.messages[1].role", equalTo("system")))
-                .withRequestBody(matchingJsonPath("$.messages[2].content", containing("iPhone 13 Pro"))));
+                .withRequestBody(matchingJsonPath("$.messages[1].role", equalTo("user")))
+                .withRequestBody(matchingJsonPath("$.messages[1].content", containing("iPhone 13 Pro"))));
     }
 
     @Test

--- a/src/test/java/com/awesome/testing/endpoints/ollama/OllamaLearningControllerTest.java
+++ b/src/test/java/com/awesome/testing/endpoints/ollama/OllamaLearningControllerTest.java
@@ -1,0 +1,109 @@
+package com.awesome.testing.endpoints.ollama;
+
+import com.awesome.testing.dto.ollama.LearningNextTokenRequestDto;
+import com.awesome.testing.dto.ollama.LearningNextTokenResponseDto;
+import com.awesome.testing.dto.user.Role;
+import com.awesome.testing.dto.user.UserRegisterDto;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.awesome.testing.factory.UserFactory.getRandomUserWithRoles;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Tag("integration")
+class OllamaLearningControllerTest extends AbstractOllamaTest {
+
+    private static final String ENDPOINT = "/api/v1/ollama/learning/next-token";
+    private String authToken;
+
+    @BeforeAll
+    void initAuthToken() {
+        UserRegisterDto user = getRandomUserWithRoles(List.of(Role.ROLE_CLIENT));
+        authToken = getToken(user);
+    }
+
+    @Test
+    void returnsLiveDistributionAndSendsOneRawTokenRequest() {
+        OllamaMock.stubSuccessfulNextTokenLogprobs();
+
+        ResponseEntity<LearningNextTokenResponseDto> response = executePost(
+                ENDPOINT, validRequest(), getHeadersWith(authToken), LearningNextTokenResponseDto.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getSource()).isEqualTo("ollama-live");
+        assertThat(response.getBody().getCandidates()).hasSize(3);
+        assertThat(response.getBody().getCandidates().getFirst().getToken()).isEqualTo(" Paris");
+
+        verify(postRequestedFor(urlEqualTo("/api/generate"))
+                .withRequestBody(matchingJsonPath("$.model", equalTo("llama3.2:1b")))
+                .withRequestBody(matchingJsonPath("$.prompt", equalTo("The capital of France is")))
+                .withRequestBody(matchingJsonPath("$.stream", equalTo("false")))
+                .withRequestBody(matchingJsonPath("$.raw", equalTo("true")))
+                .withRequestBody(matchingJsonPath("$.logprobs", equalTo("true")))
+                .withRequestBody(matchingJsonPath("$.top_logprobs", equalTo("3")))
+                .withRequestBody(matchingJsonPath("$.options.num_predict", equalTo("1"))));
+    }
+
+    @Test
+    void rejectsInvalidRequestBeforeCallingOllama() {
+        LearningNextTokenRequestDto request = LearningNextTokenRequestDto.builder()
+                .model(" ")
+                .prompt("")
+                .topK(1)
+                .build();
+
+        ResponseEntity<Map> response = executePost(ENDPOINT, request, getHeadersWith(authToken), Map.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).containsKeys("model", "prompt", "topK");
+    }
+
+    @Test
+    void requiresAuthentication() {
+        ResponseEntity<String> response = executePost(ENDPOINT, validRequest(), getJsonOnlyHeaders(), String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void reportsUnsupportedLogprobs() {
+        OllamaMock.stubMissingNextTokenLogprobs();
+
+        ResponseEntity<Map> response = executePost(ENDPOINT, validRequest(), getHeadersWith(authToken), Map.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_CONTENT);
+        assertThat(response.getBody().get("message").toString()).contains("did not return next-token log probabilities");
+    }
+
+    @Test
+    void reportsAnEmptyUpstreamResponseAsUnsupportedLogprobs() {
+        OllamaMock.stubEmptyNextTokenResponse();
+
+        ResponseEntity<Map> response = executePost(ENDPOINT, validRequest(), getHeadersWith(authToken), Map.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_CONTENT);
+        assertThat(response.getBody().get("message").toString()).contains("did not return next-token log probabilities");
+    }
+
+    private static LearningNextTokenRequestDto validRequest() {
+        return LearningNextTokenRequestDto.builder()
+                .model("llama3.2:1b")
+                .prompt("The capital of France is")
+                .topK(3)
+                .build();
+    }
+}

--- a/src/test/java/com/awesome/testing/endpoints/ollama/OllamaMock.java
+++ b/src/test/java/com/awesome/testing/endpoints/ollama/OllamaMock.java
@@ -53,6 +53,45 @@ public class OllamaMock {
                 ));
     }
 
+    public static void stubSuccessfulNextTokenLogprobs() {
+        stubFor(post(urlEqualTo("/api/generate"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {
+                                  "model":"llama3.2:1b",
+                                  "response":" Paris",
+                                  "done":true,
+                                  "logprobs":[{
+                                    "token":" Paris",
+                                    "logprob":-0.2,
+                                    "bytes":[32,80,97,114,105,115],
+                                    "top_logprobs":[
+                                      {"token":" Paris","logprob":-0.2},
+                                      {"token":" Lyon","logprob":-1.6},
+                                      {"token":" London","logprob":-2.2}
+                                    ]
+                                  }]
+                                }
+                                """)));
+    }
+
+    public static void stubMissingNextTokenLogprobs() {
+        stubFor(post(urlEqualTo("/api/generate"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {"model":"llama3.2:1b","response":" Paris","done":true,"logprobs":null}
+                                """)));
+    }
+
+    public static void stubEmptyNextTokenResponse() {
+        stubFor(post(urlEqualTo("/api/generate"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("")));
+    }
+
     // api/chat
     public static void stubSuccessfulChat() {
         stubFor(post(urlEqualTo("/api/chat"))

--- a/src/test/java/com/awesome/testing/service/ollama/OllamaFunctionCallingServiceTest.java
+++ b/src/test/java/com/awesome/testing/service/ollama/OllamaFunctionCallingServiceTest.java
@@ -1,5 +1,6 @@
 package com.awesome.testing.service.ollama;
 
+import com.awesome.testing.config.OllamaProperties;
 import com.awesome.testing.dto.ollama.*;
 import com.awesome.testing.service.ollama.function.OllamaToolRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,7 +53,8 @@ class OllamaFunctionCallingServiceTest {
 
     @BeforeEach
     void setUp() {
-        functionCallingService = new OllamaFunctionCallingService(ollamaWebClient, toolRegistry);
+        OllamaProperties properties = new OllamaProperties();
+        functionCallingService = new OllamaFunctionCallingService(ollamaWebClient, toolRegistry, properties);
     }
 
     @Test

--- a/src/test/java/com/awesome/testing/service/ollama/OllamaLearningServiceTest.java
+++ b/src/test/java/com/awesome/testing/service/ollama/OllamaLearningServiceTest.java
@@ -1,0 +1,90 @@
+package com.awesome.testing.service.ollama;
+
+import com.awesome.testing.controller.exception.CustomException;
+import com.awesome.testing.dto.ollama.LearningNextTokenRequestDto;
+import com.awesome.testing.dto.ollama.LearningNextTokenResponseDto;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+class OllamaLearningServiceTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final OllamaLearningService service = new OllamaLearningService(mock(WebClient.class), objectMapper);
+
+    @Test
+    void parsesSortsDeduplicatesAndNormalizesModernLogprobs() throws Exception {
+        LearningNextTokenRequestDto request = request(3);
+        JsonNode response = objectMapper.readTree("""
+                {
+                  "model": "llama3.2:1b",
+                  "response": " Paris",
+                  "logprobs": [{
+                    "token": " Paris",
+                    "logprob": -0.3,
+                    "top_logprobs": [
+                      {"token": " Lyon", "logprob": -3.0},
+                      {"token": " Paris", "logprob": -0.4},
+                      {"token": " London", "logprob": -2.0},
+                      {"token": " Berlin", "logprob": -4.0}
+                    ]
+                  }]
+                }
+                """);
+
+        LearningNextTokenResponseDto result = service.parseResponse(request, response);
+
+        assertThat(result.getSource()).isEqualTo("ollama-live");
+        assertThat(result.getGeneratedToken()).isEqualTo(" Paris");
+        assertThat(result.getCandidates()).extracting(candidate -> candidate.getToken())
+                .containsExactly(" Paris", " London", " Lyon");
+        assertThat(result.getCandidates()).extracting(candidate -> candidate.getRank())
+                .containsExactly(1, 2, 3);
+        assertThat(result.getCandidates().getFirst().getLogprob()).isEqualTo(-0.3d);
+        assertThat(result.getCandidates()).allSatisfy(candidate -> {
+            assertThat(candidate.getProbability()).isFinite().isPositive();
+            assertThat(candidate.getNormalizedProbability()).isFinite().isPositive();
+        });
+        assertThat(result.getCandidates().stream().mapToDouble(candidate -> candidate.getNormalizedProbability()).sum())
+                .isCloseTo(1d, org.assertj.core.data.Offset.offset(1e-12));
+        assertThat(result.isTruncated()).isTrue();
+    }
+
+    @Test
+    void usesGeneratedPositionWhenTopCandidatesAreAbsent() throws Exception {
+        JsonNode response = objectMapper.readTree("""
+                {"response":"!","logprobs":[{"token":"!","logprob":0.0}]}
+                """);
+
+        LearningNextTokenResponseDto result = service.parseResponse(request(10), response);
+
+        assertThat(result.getCandidates()).hasSize(1);
+        assertThat(result.getCandidates().getFirst().getProbability()).isEqualTo(1d);
+        assertThat(result.isTruncated()).isFalse();
+    }
+
+    @Test
+    void rejectsMissingLogprobsWithUsefulStatus() throws Exception {
+        JsonNode response = objectMapper.readTree("{\"response\":\" Paris\",\"logprobs\":null}");
+
+        assertThatThrownBy(() -> service.parseResponse(request(10), response))
+                .isInstanceOfSatisfying(CustomException.class, exception -> {
+                    assertThat(exception.getHttpStatus()).isEqualTo(HttpStatus.UNPROCESSABLE_CONTENT);
+                    assertThat(exception.getMessage()).contains("did not return next-token log probabilities");
+                });
+    }
+
+    private static LearningNextTokenRequestDto request(int topK) {
+        return LearningNextTokenRequestDto.builder()
+                .model("llama3.2:1b")
+                .prompt("The capital of France is")
+                .topK(topK)
+                .build();
+    }
+}

--- a/src/test/java/com/awesome/testing/service/ollama/function/ProductCatalogFunctionHandlerTest.java
+++ b/src/test/java/com/awesome/testing/service/ollama/function/ProductCatalogFunctionHandlerTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -101,6 +102,47 @@ class ProductCatalogFunctionHandlerTest {
 
         assertThat(result.getContent()).contains("\"total\":0");
         verify(productService).listProducts(0, 25, null, null);
+    }
+
+    @Test
+    void shouldRepairBonsaiParameterMarkupLeakedIntoCategory() {
+        ProductListDto listDto = ProductListDto.builder()
+                .products(List.of())
+                .total(0)
+                .page(0)
+                .size(100)
+                .build();
+        when(productService.listProducts(0, 100, "electronics", true)).thenReturn(listDto);
+
+        ToolCallDto toolCall = ToolCallDto.builder()
+                .function(ToolCallFunctionDto.builder()
+                        .name("list_products")
+                        .arguments(Map.of(
+                                "category", "electronics</parameter>\n<parameter=inStockOnly>\ntrue",
+                                "limit", 100
+                        ))
+                        .build())
+                .build();
+
+        ChatMessageDto result = handler.handle(toolCall);
+
+        assertThat(result.getContent()).contains("\"total\":0");
+        verify(productService).listProducts(0, 100, "electronics", true);
+    }
+
+    @Test
+    void shouldRejectUnrecognizedToolMarkupInCategory() {
+        ToolCallDto toolCall = ToolCallDto.builder()
+                .function(ToolCallFunctionDto.builder()
+                        .name("list_products")
+                        .arguments(Map.of("category", "electronics<unexpected>value"))
+                        .build())
+                .build();
+
+        ChatMessageDto result = handler.handle(toolCall);
+
+        assertThat(result.getContent()).contains("category must be a plain category name without tool markup");
+        verifyNoInteractions(productService);
     }
 
     @Test

--- a/src/test/java/com/awesome/testing/service/prompt/PromptInjectorTest.java
+++ b/src/test/java/com/awesome/testing/service/prompt/PromptInjectorTest.java
@@ -51,7 +51,7 @@ class PromptInjectorTest {
     }
 
     @Test
-    void shouldPrependChatAndToolPromptsForToolRequests() {
+    void shouldMergeChatAndToolPromptsIntoOneSystemMessageForToolRequests() {
         ChatRequestDto request = ChatRequestDto.builder()
                 .model("qwen3.5:2b")
                 .messages(List.of(ChatMessageDto.builder().role("user").content("Compare items").build()))
@@ -62,10 +62,10 @@ class PromptInjectorTest {
 
         ChatRequestDto result = promptInjector.augmentToolRequest("bob", request);
 
-        assertThat(result.getMessages()).hasSize(3);
-        assertThat(result.getMessages().get(0).getContent()).isEqualTo("Chat Prompt");
-        assertThat(result.getMessages().get(1).getContent()).isEqualTo("Tool Prompt");
-        assertThat(result.getMessages().get(2).getContent()).isEqualTo("Compare items");
+        assertThat(result.getMessages()).hasSize(2);
+        assertThat(result.getMessages().get(0).getRole()).isEqualTo("system");
+        assertThat(result.getMessages().get(0).getContent()).isEqualTo("Chat Prompt\n\nTool Prompt");
+        assertThat(result.getMessages().get(1).getContent()).isEqualTo("Compare items");
     }
 
     @Test
@@ -83,9 +83,9 @@ class PromptInjectorTest {
 
         ChatRequestDto result = promptInjector.augmentToolRequest("carol", request);
 
-        assertThat(result.getMessages()).hasSize(3);
-        assertThat(result.getMessages().get(0).getContent()).isEqualTo("Chat Prompt");
-        assertThat(result.getMessages().get(1).getContent()).isEqualTo("Tool Prompt");
-        assertThat(result.getMessages().get(2).getContent()).isEqualTo("Hi");
+        assertThat(result.getMessages()).hasSize(2);
+        assertThat(result.getMessages().get(0).getRole()).isEqualTo("system");
+        assertThat(result.getMessages().get(0).getContent()).isEqualTo("Chat Prompt\n\nTool Prompt");
+        assertThat(result.getMessages().get(1).getContent()).isEqualTo("Hi");
     }
 }


### PR DESCRIPTION
## Summary
- add an authenticated next-token logprobs teaching endpoint
- normalize Ollama top-logprob responses into a stable application contract
- make tool-call iteration limits configurable
- harden Bonsai tool argument repair and merge system prompts for compatibility

## Validation
- `./mvnw -Pfast-verify verify` (402 tests)
- `./mvnw verify` (402 tests, PMD and coverage checks)