### PR TITLE
Improve Bonsai tool-call compatibility

### DIFF
--- a/src/main/java/com/awesome/testing/config/OllamaProperties.java
+++ b/src/main/java/com/awesome/testing/config/OllamaProperties.java
@@ -10,5 +10,6 @@ import org.springframework.validation.annotation.Validated;
 public class OllamaProperties {
 
     private String baseUrl;
+    private int maxToolCallIterations = 8;
 
-} 
+}

--- a/src/main/java/com/awesome/testing/service/ollama/OllamaFunctionCallingService.java
+++ b/src/main/java/com/awesome/testing/service/ollama/OllamaFunctionCallingService.java
@@ -1,5 +1,6 @@
 package com.awesome.testing.service.ollama;
 
+import com.awesome.testing.config.OllamaProperties;
 import com.awesome.testing.dto.ollama.ChatMessageDto;
 import com.awesome.testing.dto.ollama.ChatRequestDto;
 import com.awesome.testing.dto.ollama.ChatResponseDto;
@@ -23,10 +24,9 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public class OllamaFunctionCallingService {
 
-    private static final int MAX_TOOL_CALL_ITERATIONS = 3;
-
     private final WebClient ollamaWebClient;
     private final OllamaToolRegistry toolRegistry;
+    private final OllamaProperties ollamaProperties;
 
     public Flux<ChatResponseDto> chatWithTools(ChatRequestDto request) {
         if (request.getTools() == null || request.getTools().isEmpty()) {
@@ -44,8 +44,9 @@ public class OllamaFunctionCallingService {
                                                 List<ChatMessageDto> history,
                                                 int iteration,
                                                 OllamaRequestHandler ctx) {
-        if (iteration >= MAX_TOOL_CALL_ITERATIONS) {
-            log.error("Exceeded maximum tool call iterations ({}) for model {}", MAX_TOOL_CALL_ITERATIONS, baseRequest.getModel());
+        int maxIterations = ollamaProperties.getMaxToolCallIterations();
+        if (iteration >= maxIterations) {
+            log.error("Exceeded maximum tool call iterations ({}) for model {}", maxIterations, baseRequest.getModel());
             return Flux.error(new IllegalStateException("Exceeded maximum tool call iterations"));
         }
 

--- a/src/main/java/com/awesome/testing/service/ollama/OllamaToolDefinitionCatalog.java
+++ b/src/main/java/com/awesome/testing/service/ollama/OllamaToolDefinitionCatalog.java
@@ -66,7 +66,7 @@ public class OllamaToolDefinitionCatalog {
                                 .properties(Map.of(
                                         "offset", property("integer", "Zero-based offset into the catalog (default 0)."),
                                         "limit", property("integer", "Number of products to fetch (default 25, max 100)."),
-                                        "category", property("string", "Case-insensitive category filter, e.g., 'electronics'."),
+                                        "category", property("string", "Plain case-insensitive category name, e.g., 'electronics'. Never include XML or <parameter> markup in this value."),
                                         "inStockOnly", property("boolean", "If true, only return products with stockQuantity > 0.")
                                 ))
                                 .build())

--- a/src/main/java/com/awesome/testing/service/ollama/function/ProductCatalogFunctionHandler.java
+++ b/src/main/java/com/awesome/testing/service/ollama/function/ProductCatalogFunctionHandler.java
@@ -11,6 +11,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Slf4j
 @Component
@@ -18,6 +20,9 @@ import java.util.Map;
 public class ProductCatalogFunctionHandler implements FunctionCallHandler {
 
     static final String TOOL_NAME = "list_products";
+    private static final Pattern LEAKED_IN_STOCK_ARGUMENT = Pattern.compile(
+            "^\\s*([^<>]*?)\\s*</parameter>\\s*<parameter=inStockOnly>\\s*(true|false)\\s*(?:</parameter>)?\\s*$",
+            Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
     private final ProductService productService;
     private final ObjectMapper objectMapper;
@@ -33,10 +38,13 @@ public class ProductCatalogFunctionHandler implements FunctionCallHandler {
             Map<String, Object> args = toolCall.getFunction().getArguments();
             int offset = parseInt(args != null ? args.get("offset") : null, 0);
             int limit = parseInt(args != null ? args.get("limit") : null, 25);
-            String category = parseCategory(args != null ? args.get("category") : null);
-            Boolean inStockOnly = parseBoolean(args != null ? args.get("inStockOnly") : null);
+            ParsedCategory parsedCategory = parseCategory(args != null ? args.get("category") : null);
+            Boolean explicitInStockOnly = parseBoolean(args != null ? args.get("inStockOnly") : null);
+            Boolean inStockOnly = explicitInStockOnly != null
+                    ? explicitInStockOnly
+                    : parsedCategory.leakedInStockOnly();
 
-            ProductListDto list = productService.listProducts(offset, limit, category, inStockOnly);
+            ProductListDto list = productService.listProducts(offset, limit, parsedCategory.category(), inStockOnly);
             return ChatMessageDto.builder()
                     .role("tool")
                     .toolName(TOOL_NAME)
@@ -68,12 +76,28 @@ public class ProductCatalogFunctionHandler implements FunctionCallHandler {
         throw new IllegalArgumentException("Unsupported number format");
     }
 
-    private String parseCategory(Object value) {
+    private ParsedCategory parseCategory(Object value) {
         if (value == null) {
-            return null;
+            return new ParsedCategory(null, null);
         }
         String category = value.toString().trim();
-        return category.isBlank() ? null : category;
+        if (category.isBlank()) {
+            return new ParsedCategory(null, null);
+        }
+
+        Matcher leakedArgument = LEAKED_IN_STOCK_ARGUMENT.matcher(category);
+        if (leakedArgument.matches()) {
+            String repairedCategory = leakedArgument.group(1).trim();
+            Boolean repairedInStockOnly = Boolean.valueOf(leakedArgument.group(2));
+            log.warn("Repaired leaked tool markup in list_products category; category='{}', inStockOnly={}",
+                    repairedCategory, repairedInStockOnly);
+            return new ParsedCategory(repairedCategory.isBlank() ? null : repairedCategory, repairedInStockOnly);
+        }
+
+        if (category.contains("<") || category.contains(">")) {
+            throw new IllegalArgumentException("category must be a plain category name without tool markup");
+        }
+        return new ParsedCategory(category, null);
     }
 
     private Boolean parseBoolean(Object value) {
@@ -103,5 +127,8 @@ public class ProductCatalogFunctionHandler implements FunctionCallHandler {
                     .content("{\"error\":\"" + message + "\"}")
                     .build();
         }
+    }
+
+    private record ParsedCategory(String category, Boolean leakedInStockOnly) {
     }
 }

--- a/src/main/java/com/awesome/testing/service/prompt/PromptInjector.java
+++ b/src/main/java/com/awesome/testing/service/prompt/PromptInjector.java
@@ -32,10 +32,7 @@ public class PromptInjector {
         List<ChatMessageDto> cleanedHistory = stripExistingPrompts(original.getMessages(), chatPrompt, toolPrompt);
 
         List<ChatMessageDto> augmentedHistory = new ArrayList<>();
-        augmentedHistory.add(systemMessage(chatPrompt));
-        if (includeToolPrompt) {
-            augmentedHistory.add(systemMessage(toolPrompt));
-        }
+        augmentedHistory.add(systemMessage(mergePrompts(chatPrompt, toolPrompt)));
         augmentedHistory.addAll(cleanedHistory);
 
         return ChatRequestDto.builder()
@@ -47,6 +44,16 @@ public class PromptInjector {
                 .keepAlive(original.getKeepAlive())
                 .think(original.getThink())
                 .build();
+    }
+
+    private static String mergePrompts(String chatPrompt, String toolPrompt) {
+        if (toolPrompt == null || toolPrompt.isBlank()) {
+            return chatPrompt;
+        }
+        if (chatPrompt == null || chatPrompt.isBlank()) {
+            return toolPrompt;
+        }
+        return chatPrompt.strip() + "\n\n" + toolPrompt.strip();
     }
 
     private static List<ChatMessageDto> stripExistingPrompts(List<ChatMessageDto> history,

--- a/src/test/java/com/awesome/testing/endpoints/ollama/OllamaChatControllerTest.java
+++ b/src/test/java/com/awesome/testing/endpoints/ollama/OllamaChatControllerTest.java
@@ -263,8 +263,8 @@ class OllamaChatControllerTest extends AbstractOllamaTest {
         verify(postRequestedFor(urlEqualTo("/api/chat"))
                 .withRequestBody(matchingJsonPath("$.tools[0].function.name", equalTo("get_product_snapshot")))
                 .withRequestBody(matchingJsonPath("$.messages[0].role", equalTo("system")))
-                .withRequestBody(matchingJsonPath("$.messages[1].role", equalTo("system")))
-                .withRequestBody(matchingJsonPath("$.messages[2].content", containing("iPhone 13 Pro"))));
+                .withRequestBody(matchingJsonPath("$.messages[1].role", equalTo("user")))
+                .withRequestBody(matchingJsonPath("$.messages[1].content", containing("iPhone 13 Pro"))));
     }
 
     @Test

--- a/src/test/java/com/awesome/testing/service/ollama/OllamaFunctionCallingServiceTest.java
+++ b/src/test/java/com/awesome/testing/service/ollama/OllamaFunctionCallingServiceTest.java
@@ -1,5 +1,6 @@
 package com.awesome.testing.service.ollama;
 
+import com.awesome.testing.config.OllamaProperties;
 import com.awesome.testing.dto.ollama.*;
 import com.awesome.testing.service.ollama.function.OllamaToolRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,7 +53,8 @@ class OllamaFunctionCallingServiceTest {
 
     @BeforeEach
     void setUp() {
-        functionCallingService = new OllamaFunctionCallingService(ollamaWebClient, toolRegistry);
+        OllamaProperties properties = new OllamaProperties();
+        functionCallingService = new OllamaFunctionCallingService(ollamaWebClient, toolRegistry, properties);
     }
 
     @Test

--- a/src/test/java/com/awesome/testing/service/ollama/function/ProductCatalogFunctionHandlerTest.java
+++ b/src/test/java/com/awesome/testing/service/ollama/function/ProductCatalogFunctionHandlerTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -101,6 +102,47 @@ class ProductCatalogFunctionHandlerTest {
 
         assertThat(result.getContent()).contains("\"total\":0");
         verify(productService).listProducts(0, 25, null, null);
+    }
+
+    @Test
+    void shouldRepairBonsaiParameterMarkupLeakedIntoCategory() {
+        ProductListDto listDto = ProductListDto.builder()
+                .products(List.of())
+                .total(0)
+                .page(0)
+                .size(100)
+                .build();
+        when(productService.listProducts(0, 100, "electronics", true)).thenReturn(listDto);
+
+        ToolCallDto toolCall = ToolCallDto.builder()
+                .function(ToolCallFunctionDto.builder()
+                        .name("list_products")
+                        .arguments(Map.of(
+                                "category", "electronics</parameter>\n<parameter=inStockOnly>\ntrue",
+                                "limit", 100
+                        ))
+                        .build())
+                .build();
+
+        ChatMessageDto result = handler.handle(toolCall);
+
+        assertThat(result.getContent()).contains("\"total\":0");
+        verify(productService).listProducts(0, 100, "electronics", true);
+    }
+
+    @Test
+    void shouldRejectUnrecognizedToolMarkupInCategory() {
+        ToolCallDto toolCall = ToolCallDto.builder()
+                .function(ToolCallFunctionDto.builder()
+                        .name("list_products")
+                        .arguments(Map.of("category", "electronics<unexpected>value"))
+                        .build())
+                .build();
+
+        ChatMessageDto result = handler.handle(toolCall);
+
+        assertThat(result.getContent()).contains("category must be a plain category name without tool markup");
+        verifyNoInteractions(productService);
     }
 
     @Test

--- a/src/test/java/com/awesome/testing/service/prompt/PromptInjectorTest.java
+++ b/src/test/java/com/awesome/testing/service/prompt/PromptInjectorTest.java
@@ -51,7 +51,7 @@ class PromptInjectorTest {
     }
 
     @Test
-    void shouldPrependChatAndToolPromptsForToolRequests() {
+    void shouldMergeChatAndToolPromptsIntoOneSystemMessageForToolRequests() {
         ChatRequestDto request = ChatRequestDto.builder()
                 .model("qwen3.5:2b")
                 .messages(List.of(ChatMessageDto.builder().role("user").content("Compare items").build()))
@@ -62,10 +62,10 @@ class PromptInjectorTest {
 
         ChatRequestDto result = promptInjector.augmentToolRequest("bob", request);
 
-        assertThat(result.getMessages()).hasSize(3);
-        assertThat(result.getMessages().get(0).getContent()).isEqualTo("Chat Prompt");
-        assertThat(result.getMessages().get(1).getContent()).isEqualTo("Tool Prompt");
-        assertThat(result.getMessages().get(2).getContent()).isEqualTo("Compare items");
+        assertThat(result.getMessages()).hasSize(2);
+        assertThat(result.getMessages().get(0).getRole()).isEqualTo("system");
+        assertThat(result.getMessages().get(0).getContent()).isEqualTo("Chat Prompt\n\nTool Prompt");
+        assertThat(result.getMessages().get(1).getContent()).isEqualTo("Compare items");
     }
 
     @Test
@@ -83,9 +83,9 @@ class PromptInjectorTest {
 
         ChatRequestDto result = promptInjector.augmentToolRequest("carol", request);
 
-        assertThat(result.getMessages()).hasSize(3);
-        assertThat(result.getMessages().get(0).getContent()).isEqualTo("Chat Prompt");
-        assertThat(result.getMessages().get(1).getContent()).isEqualTo("Tool Prompt");
-        assertThat(result.getMessages().get(2).getContent()).isEqualTo("Hi");
+        assertThat(result.getMessages()).hasSize(2);
+        assertThat(result.getMessages().get(0).getRole()).isEqualTo("system");
+        assertThat(result.getMessages().get(0).getContent()).isEqualTo("Chat Prompt\n\nTool Prompt");
+        assertThat(result.getMessages().get(1).getContent()).isEqualTo("Hi");
     }
 }


### PR DESCRIPTION
## Summary
- merge chat and tool guidance into one system message for Bonsai compatibility
- make tool-call iteration count configurable
- normalize the known Bonsai category parameter serialization while rejecting arbitrary markup
- keep the existing Qwen/mock API contract compatible

## Verification
- `./mvnw -Pintegration-tests verify`
- 394 unit tests passed
- 32 integration tests passed
- PMD and JaCoCo checks passed