### PR TITLE
Add AI Lab learning and GPT-2 APIs

### DIFF
--- a/src/main/java/com/awesome/testing/controller/Gpt2InspectorController.java
+++ b/src/main/java/com/awesome/testing/controller/Gpt2InspectorController.java
@@ -1,0 +1,89 @@
+package com.awesome.testing.controller;
+
+import com.awesome.testing.dto.gpt2.Gpt2InspectorStatusDto;
+import com.awesome.testing.dto.gpt2.Gpt2EmbeddingSpaceRequestDto;
+import com.awesome.testing.dto.gpt2.Gpt2TraceRequestDto;
+import com.awesome.testing.security.CustomPrincipal;
+import com.awesome.testing.security.ratelimit.AuthRateLimitGuard;
+import com.awesome.testing.service.gpt2.Gpt2InspectorService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import tools.jackson.databind.JsonNode;
+
+@RestController
+@RequestMapping("/api/v1/learning/gpt2")
+@Tag(name = "gpt2-inspector", description = "Full-local GPT-2 activation inspector")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
+@ApiResponse(responseCode = "401", description = "Unauthorized")
+public class Gpt2InspectorController {
+
+    private final Gpt2InspectorService inspectorService;
+    private final AuthRateLimitGuard authRateLimitGuard;
+
+    @Operation(
+            summary = "Discover the optional full-local GPT-2 inspector",
+            description = "Reports whether the private GPT-2 activation sidecar is configured, loaded, and ready."
+    )
+    @ApiResponse(responseCode = "200", description = "Inspector availability returned successfully")
+    @GetMapping(value = "/status", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Gpt2InspectorStatusDto status() {
+        return inspectorService.status();
+    }
+
+    @Operation(
+            summary = "Capture exact activations from GPT-2 small",
+            description = "Runs the pinned local GPT-2 model and returns exact selected-head attention and residual tensors."
+    )
+    @ApiResponse(responseCode = "200", description = "Activation trace captured successfully")
+    @ApiResponse(responseCode = "503", description = "The full-local inspector is not enabled")
+    @PostMapping(value = "/trace", produces = MediaType.APPLICATION_JSON_VALUE)
+    public JsonNode trace(
+            HttpServletRequest servletRequest,
+            @AuthenticationPrincipal CustomPrincipal principal,
+            @Valid @RequestBody Gpt2TraceRequestDto request) {
+        authRateLimitGuard.checkOllama(servletRequest, principal != null ? principal.getUsername() : null);
+        return inspectorService.trace(request);
+    }
+
+    @Operation(
+            summary = "Explore the complete GPT-2 embedding table",
+            description = "Finds a token across all GPT-2 vocabulary rows and returns a readable local 3D projection of its nearest embedding neighbors."
+    )
+    @ApiResponse(responseCode = "200", description = "Focused embedding neighborhood returned successfully")
+    @ApiResponse(responseCode = "503", description = "The full-local inspector is not enabled")
+    @PostMapping(value = "/embedding-space", produces = MediaType.APPLICATION_JSON_VALUE)
+    public JsonNode embeddingSpace(
+            HttpServletRequest servletRequest,
+            @AuthenticationPrincipal CustomPrincipal principal,
+            @Valid @RequestBody Gpt2EmbeddingSpaceRequestDto request) {
+        authRateLimitGuard.checkOllama(servletRequest, principal != null ? principal.getUsername() : null);
+        return inspectorService.embeddingSpace(request);
+    }
+
+    @Operation(
+            summary = "Project the complete GPT-2 embedding table",
+            description = "Returns a cached global 3D PCA projection for all 50,257 GPT-2 input embedding rows."
+    )
+    @ApiResponse(responseCode = "200", description = "Complete embedding projection returned successfully")
+    @ApiResponse(responseCode = "503", description = "The full-local inspector is not enabled")
+    @GetMapping(value = "/embedding-forest", produces = MediaType.APPLICATION_JSON_VALUE)
+    public JsonNode embeddingForest(
+            HttpServletRequest servletRequest,
+            @AuthenticationPrincipal CustomPrincipal principal) {
+        authRateLimitGuard.checkOllama(servletRequest, principal != null ? principal.getUsername() : null);
+        return inspectorService.embeddingForest();
+    }
+}

--- a/src/main/java/com/awesome/testing/controller/OllamaController.java
+++ b/src/main/java/com/awesome/testing/controller/OllamaController.java
@@ -3,12 +3,19 @@ package com.awesome.testing.controller;
 import com.awesome.testing.dto.ollama.ChatRequestDto;
 import com.awesome.testing.dto.ollama.ChatResponseDto;
 import com.awesome.testing.dto.ollama.GenerateResponseDto;
+import com.awesome.testing.dto.ollama.LearningEmbeddingRequestDto;
+import com.awesome.testing.dto.ollama.LearningEmbeddingResponseDto;
 import com.awesome.testing.dto.ollama.ModelNotFoundDto;
+import com.awesome.testing.dto.ollama.LearningNextTokenRequestDto;
+import com.awesome.testing.dto.ollama.LearningNextTokenResponseDto;
+import com.awesome.testing.dto.ollama.LearningTokenCountRequestDto;
+import com.awesome.testing.dto.ollama.LearningTokenCountResponseDto;
 import com.awesome.testing.dto.ollama.OllamaToolDefinitionDto;
 import com.awesome.testing.dto.ollama.StreamedRequestDto;
 import com.awesome.testing.security.CustomPrincipal;
 import com.awesome.testing.security.ratelimit.AuthRateLimitGuard;
 import com.awesome.testing.service.ollama.OllamaFunctionCallingService;
+import com.awesome.testing.service.ollama.OllamaLearningService;
 import com.awesome.testing.service.ollama.OllamaService;
 import com.awesome.testing.service.ollama.OllamaToolDefinitionCatalog;
 import com.awesome.testing.service.prompt.PromptInjector;
@@ -44,10 +51,56 @@ import java.util.List;
 public class OllamaController {
 
     private final OllamaService ollamaService;
+    private final OllamaLearningService ollamaLearningService;
     private final OllamaFunctionCallingService functionCallingService;
     private final OllamaToolDefinitionCatalog toolDefinitionCatalog;
     private final PromptInjector promptInjector;
     private final AuthRateLimitGuard authRateLimitGuard;
+
+    @Operation(summary = "Inspect live next-token probabilities",
+            description = "Runs one raw Ollama generation step and returns a stable, ranked top-logprob teaching response.")
+    @ApiResponse(responseCode = "200", description = "Next-token candidates returned successfully")
+    @ApiResponse(responseCode = "400", description = "Invalid request")
+    @ApiResponse(responseCode = "422", description = "The selected model or runtime did not expose logprobs")
+    @ApiResponse(responseCode = "429", description = "Too many requests")
+    @PostMapping(value = "/learning/next-token", produces = MediaType.APPLICATION_JSON_VALUE)
+    public LearningNextTokenResponseDto nextTokenDistribution(
+            HttpServletRequest servletRequest,
+            @AuthenticationPrincipal CustomPrincipal principal,
+            @Valid @RequestBody LearningNextTokenRequestDto request) {
+        authRateLimitGuard.checkOllama(servletRequest, principal != null ? principal.getUsername() : null);
+        return ollamaLearningService.nextTokenDistribution(request).block();
+    }
+
+    @Operation(summary = "Verify a prompt token count with Ollama",
+            description = "Runs one raw generation step and returns the number of prompt tokens processed by the model.")
+    @ApiResponse(responseCode = "200", description = "Prompt token count returned successfully")
+    @ApiResponse(responseCode = "400", description = "Invalid request")
+    @ApiResponse(responseCode = "422", description = "The selected model or runtime did not expose a prompt token count")
+    @ApiResponse(responseCode = "429", description = "Too many requests")
+    @PostMapping(value = "/learning/token-count", produces = MediaType.APPLICATION_JSON_VALUE)
+    public LearningTokenCountResponseDto countPromptTokens(
+            HttpServletRequest servletRequest,
+            @AuthenticationPrincipal CustomPrincipal principal,
+            @Valid @RequestBody LearningTokenCountRequestDto request) {
+        authRateLimitGuard.checkOllama(servletRequest, principal != null ? principal.getUsername() : null);
+        return ollamaLearningService.countPromptTokens(request).block();
+    }
+
+    @Operation(summary = "Generate text embeddings for the learning lab",
+            description = "Embeds two to eight texts with a dedicated Ollama embedding model.")
+    @ApiResponse(responseCode = "200", description = "Embedding vectors returned successfully")
+    @ApiResponse(responseCode = "400", description = "Invalid request")
+    @ApiResponse(responseCode = "422", description = "The selected model or runtime did not return valid embeddings")
+    @ApiResponse(responseCode = "429", description = "Too many requests")
+    @PostMapping(value = "/learning/embeddings", produces = MediaType.APPLICATION_JSON_VALUE)
+    public LearningEmbeddingResponseDto embedTexts(
+            HttpServletRequest servletRequest,
+            @AuthenticationPrincipal CustomPrincipal principal,
+            @Valid @RequestBody LearningEmbeddingRequestDto request) {
+        authRateLimitGuard.checkOllama(servletRequest, principal != null ? principal.getUsername() : null);
+        return ollamaLearningService.embedTexts(request).block();
+    }
 
     @Operation(summary = "Generate text using Ollama model",
             description = "Streams generated text chunks from the configured Ollama backend for a single prompt.")

--- a/src/main/java/com/awesome/testing/controller/exception/OllamaExceptionHandler.java
+++ b/src/main/java/com/awesome/testing/controller/exception/OllamaExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import java.time.Instant;
@@ -28,6 +29,18 @@ public class OllamaExceptionHandler {
                 .status(ex.getStatusCode())
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(ex.getResponseBodyAsString());
+    }
+
+    @ExceptionHandler(WebClientRequestException.class)
+    public ResponseEntity<ErrorResponse> handleWebClientRequestException(WebClientRequestException ex) {
+        return ResponseEntity
+                .status(503)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(new ErrorResponse(
+                        503,
+                        "Ollama is unavailable. Start the local Ollama service and try again.",
+                        Instant.now().toString()
+                ));
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)

--- a/src/main/java/com/awesome/testing/dto/gpt2/Gpt2EmbeddingSpaceRequestDto.java
+++ b/src/main/java/com/awesome/testing/dto/gpt2/Gpt2EmbeddingSpaceRequestDto.java
@@ -1,0 +1,28 @@
+package com.awesome.testing.dto.gpt2;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Gpt2EmbeddingSpaceRequestDto {
+
+    @Size(min = 1, max = 80)
+    private String query;
+
+    @Min(0)
+    @Max(50256)
+    private Integer tokenId;
+
+    @Min(6)
+    @Max(24)
+    @Builder.Default
+    private int neighborCount = 14;
+}

--- a/src/main/java/com/awesome/testing/dto/gpt2/Gpt2InspectorStatusDto.java
+++ b/src/main/java/com/awesome/testing/dto/gpt2/Gpt2InspectorStatusDto.java
@@ -1,0 +1,21 @@
+package com.awesome.testing.dto.gpt2;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Gpt2InspectorStatusDto {
+    private boolean available;
+    private String mode;
+    private String message;
+    private String modelLabel;
+    private String modelRevision;
+    private Integer layerCount;
+    private Integer headCount;
+    private Integer maxTokens;
+}

--- a/src/main/java/com/awesome/testing/dto/gpt2/Gpt2TraceRequestDto.java
+++ b/src/main/java/com/awesome/testing/dto/gpt2/Gpt2TraceRequestDto.java
@@ -1,0 +1,33 @@
+package com.awesome.testing.dto.gpt2;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Gpt2TraceRequestDto {
+
+    @NotBlank
+    @Size(max = 800)
+    private String prompt;
+
+    @Min(0)
+    @Max(11)
+    private int layer;
+
+    @Min(0)
+    @Max(11)
+    private int head;
+
+    @Min(0)
+    @Max(31)
+    private Integer selectedTokenIndex;
+}

--- a/src/main/java/com/awesome/testing/dto/ollama/LearningEmbeddingRequestDto.java
+++ b/src/main/java/com/awesome/testing/dto/ollama/LearningEmbeddingRequestDto.java
@@ -1,0 +1,29 @@
+package com.awesome.testing.dto.ollama;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LearningEmbeddingRequestDto {
+
+    @NotBlank
+    @Size(max = 200)
+    @Schema(description = "Installed Ollama embedding model", example = "embeddinggemma")
+    private String model;
+
+    @NotNull
+    @Size(min = 2, max = 8)
+    @Schema(description = "Two to eight short texts to embed and compare")
+    private List<@NotBlank @Size(max = 500) String> inputs;
+}

--- a/src/main/java/com/awesome/testing/dto/ollama/LearningEmbeddingResponseDto.java
+++ b/src/main/java/com/awesome/testing/dto/ollama/LearningEmbeddingResponseDto.java
@@ -1,0 +1,21 @@
+package com.awesome.testing.dto.ollama;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LearningEmbeddingResponseDto {
+
+    private String source;
+    private String modelLabel;
+    private int dimensions;
+    private int promptTokenCount;
+    private List<List<Double>> vectors;
+}

--- a/src/main/java/com/awesome/testing/dto/ollama/LearningNextTokenCandidateDto.java
+++ b/src/main/java/com/awesome/testing/dto/ollama/LearningNextTokenCandidateDto.java
@@ -1,0 +1,18 @@
+package com.awesome.testing.dto.ollama;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LearningNextTokenCandidateDto {
+    private String token;
+    private int rank;
+    private double logprob;
+    private double probability;
+    private double normalizedProbability;
+}

--- a/src/main/java/com/awesome/testing/dto/ollama/LearningNextTokenRequestDto.java
+++ b/src/main/java/com/awesome/testing/dto/ollama/LearningNextTokenRequestDto.java
@@ -1,0 +1,36 @@
+package com.awesome.testing.dto.ollama;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LearningNextTokenRequestDto {
+
+    @NotBlank
+    @Size(max = 200)
+    @Schema(description = "Installed Ollama model to inspect", example = "llama3.2:1b")
+    private String model;
+
+    @NotBlank
+    @Size(max = 2000)
+    @Schema(description = "Raw prompt whose next-token distribution should be inspected")
+    private String prompt;
+
+    @NotNull
+    @Min(2)
+    @Max(20)
+    @Builder.Default
+    @Schema(description = "Number of candidate tokens requested from Ollama", defaultValue = "10")
+    private Integer topK = 10;
+}

--- a/src/main/java/com/awesome/testing/dto/ollama/LearningNextTokenResponseDto.java
+++ b/src/main/java/com/awesome/testing/dto/ollama/LearningNextTokenResponseDto.java
@@ -1,0 +1,22 @@
+package com.awesome.testing.dto.ollama;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LearningNextTokenResponseDto {
+    private String source;
+    private String modelLabel;
+    private String prompt;
+    private String generatedToken;
+    private double capturedProbabilityMass;
+    private boolean truncated;
+    private List<LearningNextTokenCandidateDto> candidates;
+}

--- a/src/main/java/com/awesome/testing/dto/ollama/LearningTokenCountRequestDto.java
+++ b/src/main/java/com/awesome/testing/dto/ollama/LearningTokenCountRequestDto.java
@@ -1,0 +1,26 @@
+package com.awesome.testing.dto.ollama;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LearningTokenCountRequestDto {
+
+    @NotBlank
+    @Size(max = 200)
+    @Schema(description = "Installed Ollama generation model", example = "hf.co/prism-ml/Bonsai-27B-gguf:Q1_0")
+    private String model;
+
+    @NotBlank
+    @Size(max = 2000)
+    @Schema(description = "Raw prompt whose tokenizer count should be verified")
+    private String prompt;
+}

--- a/src/main/java/com/awesome/testing/dto/ollama/LearningTokenCountResponseDto.java
+++ b/src/main/java/com/awesome/testing/dto/ollama/LearningTokenCountResponseDto.java
@@ -1,0 +1,19 @@
+package com.awesome.testing.dto.ollama;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LearningTokenCountResponseDto {
+
+    private String source;
+    private String modelLabel;
+    private String prompt;
+    private int promptTokenCount;
+    private String generatedToken;
+}

--- a/src/main/java/com/awesome/testing/service/gpt2/Gpt2InspectorService.java
+++ b/src/main/java/com/awesome/testing/service/gpt2/Gpt2InspectorService.java
@@ -1,0 +1,167 @@
+package com.awesome.testing.service.gpt2;
+
+import com.awesome.testing.controller.exception.CustomException;
+import com.awesome.testing.dto.gpt2.Gpt2InspectorStatusDto;
+import com.awesome.testing.dto.gpt2.Gpt2EmbeddingSpaceRequestDto;
+import com.awesome.testing.dto.gpt2.Gpt2TraceRequestDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import tools.jackson.databind.JsonNode;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class Gpt2InspectorService {
+
+    private static final String FULL_LOCAL_MESSAGE =
+            "Real GPT-2 activations are available only in the full local profile";
+    private static final int INSPECTOR_RESPONSE_LIMIT_BYTES = 32 * 1024 * 1024;
+    private static final Duration STATUS_TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration INSPECTION_TIMEOUT = Duration.ofMinutes(2);
+
+    @Value("${gpt2-inspector.base-url:}")
+    private String baseUrl;
+
+    public Gpt2InspectorStatusDto status() {
+        if (!isConfigured()) {
+            return unavailable(FULL_LOCAL_MESSAGE);
+        }
+
+        try {
+            JsonNode health = client().get()
+                    .uri("/health")
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .timeout(STATUS_TIMEOUT)
+                    .block();
+            if (health == null || !"ready".equals(health.path("status").asString())) {
+                return unavailable("The full-local GPT-2 inspector is still loading");
+            }
+            return Gpt2InspectorStatusDto.builder()
+                    .available(true)
+                    .mode("full-local")
+                    .message("Real GPT-2 activations are ready")
+                    .modelLabel(health.path("modelLabel").asString("openai-community/gpt2"))
+                    .modelRevision(health.path("modelRevision").asString())
+                    .layerCount(health.path("layerCount").asInt(12))
+                    .headCount(health.path("headCount").asInt(12))
+                    .maxTokens(health.path("maxTokens").asInt(32))
+                    .build();
+        } catch (RuntimeException exception) {
+            return unavailable("The full-local GPT-2 inspector is starting or unavailable");
+        }
+    }
+
+    public JsonNode trace(Gpt2TraceRequestDto request) {
+        return post("/trace", request, "trace");
+    }
+
+    public JsonNode embeddingSpace(Gpt2EmbeddingSpaceRequestDto request) {
+        if ((request.getQuery() == null || request.getQuery().isBlank()) && request.getTokenId() == null) {
+            throw new CustomException("Provide a query or tokenId", HttpStatus.BAD_REQUEST);
+        }
+        return post("/embedding-space", request, "embedding neighborhood");
+    }
+
+    public JsonNode embeddingForest() {
+        if (!isConfigured()) {
+            throw new CustomException(FULL_LOCAL_MESSAGE, HttpStatus.SERVICE_UNAVAILABLE);
+        }
+
+        try {
+            JsonNode response = client().get()
+                    .uri("/embedding-forest")
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .timeout(INSPECTION_TIMEOUT)
+                    .block();
+            if (response == null) {
+                throw new CustomException("GPT-2 inspector returned an empty embedding forest", HttpStatus.BAD_GATEWAY);
+            }
+            return response;
+        } catch (CustomException exception) {
+            throw exception;
+        } catch (WebClientResponseException exception) {
+            throw inspectorFailure("embedding forest", exception);
+        } catch (RuntimeException exception) {
+            log.error("GPT-2 inspector embedding forest request failed", exception);
+            throw new CustomException(
+                    "The full-local GPT-2 inspector could not produce the embedding forest",
+                    HttpStatus.BAD_GATEWAY,
+                    exception
+            );
+        }
+    }
+
+    private JsonNode post(String path, Object request, String label) {
+        if (!isConfigured()) {
+            throw new CustomException(FULL_LOCAL_MESSAGE, HttpStatus.SERVICE_UNAVAILABLE);
+        }
+
+        try {
+            JsonNode response = client().post()
+                    .uri(path)
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .timeout(INSPECTION_TIMEOUT)
+                    .block();
+            if (response == null) {
+                throw new CustomException("GPT-2 inspector returned an empty " + label, HttpStatus.BAD_GATEWAY);
+            }
+            return response;
+        } catch (CustomException exception) {
+            throw exception;
+        } catch (WebClientResponseException exception) {
+            throw inspectorFailure(label, exception);
+        } catch (RuntimeException exception) {
+            log.error("GPT-2 inspector {} request failed", label, exception);
+            throw new CustomException(
+                    "The full-local GPT-2 inspector could not produce the " + label,
+                    HttpStatus.BAD_GATEWAY,
+                    exception
+            );
+        }
+    }
+
+    private boolean isConfigured() {
+        return baseUrl != null && !baseUrl.isBlank();
+    }
+
+    private static CustomException inspectorFailure(String label, WebClientResponseException exception) {
+        if (exception.getStatusCode().is4xxClientError()) {
+            return new CustomException(
+                    "The full-local GPT-2 inspector rejected the " + label + " request",
+                    HttpStatus.BAD_REQUEST,
+                    exception
+            );
+        }
+        return new CustomException(
+                "The full-local GPT-2 inspector could not produce the " + label,
+                HttpStatus.BAD_GATEWAY,
+                exception
+        );
+    }
+
+    private WebClient client() {
+        return WebClient.builder()
+                .baseUrl(baseUrl)
+                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(INSPECTOR_RESPONSE_LIMIT_BYTES))
+                .build();
+    }
+
+    private static Gpt2InspectorStatusDto unavailable(String message) {
+        return Gpt2InspectorStatusDto.builder()
+                .available(false)
+                .mode("full-local")
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/awesome/testing/service/ollama/OllamaLearningService.java
+++ b/src/main/java/com/awesome/testing/service/ollama/OllamaLearningService.java
@@ -1,0 +1,268 @@
+package com.awesome.testing.service.ollama;
+
+import com.awesome.testing.controller.exception.CustomException;
+import com.awesome.testing.dto.ollama.LearningNextTokenCandidateDto;
+import com.awesome.testing.dto.ollama.LearningNextTokenRequestDto;
+import com.awesome.testing.dto.ollama.LearningNextTokenResponseDto;
+import com.awesome.testing.dto.ollama.LearningEmbeddingRequestDto;
+import com.awesome.testing.dto.ollama.LearningEmbeddingResponseDto;
+import com.awesome.testing.dto.ollama.LearningTokenCountRequestDto;
+import com.awesome.testing.dto.ollama.LearningTokenCountResponseDto;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class OllamaLearningService {
+
+    private static final String SOURCE = "ollama-live";
+    private static final double COMPLETE_MASS_THRESHOLD = 0.999999d;
+    private static final int MAX_EMBEDDING_INPUT_CHARACTERS = 2000;
+    private static final int MAX_EMBEDDING_DIMENSIONS = 8192;
+
+    private final WebClient ollamaWebClient;
+    private final ObjectMapper objectMapper;
+
+    public Mono<LearningNextTokenResponseDto> nextTokenDistribution(LearningNextTokenRequestDto request) {
+        Map<String, Object> upstreamRequest = Map.of(
+                "model", request.getModel(),
+                "prompt", request.getPrompt(),
+                "stream", false,
+                "raw", true,
+                "think", false,
+                "logprobs", true,
+                "top_logprobs", request.getTopK(),
+                "options", Map.of(
+                        "temperature", 1,
+                        "num_predict", 1
+                )
+        );
+
+        return ollamaWebClient.post()
+                .uri("/api/generate")
+                .bodyValue(upstreamRequest)
+                .retrieve()
+                .bodyToMono(String.class)
+                .switchIfEmpty(Mono.error(unsupportedLogprobs()))
+                .map(this::readResponse)
+                .map(response -> parseResponse(request, response));
+    }
+
+    public Mono<LearningTokenCountResponseDto> countPromptTokens(LearningTokenCountRequestDto request) {
+        Map<String, Object> upstreamRequest = Map.of(
+                "model", request.getModel(),
+                "prompt", request.getPrompt(),
+                "stream", false,
+                "raw", true,
+                "think", false,
+                "logprobs", true,
+                "top_logprobs", 1,
+                "options", Map.of(
+                        "temperature", 0,
+                        "num_predict", 1
+                )
+        );
+
+        return postJson("/api/generate", upstreamRequest)
+                .map(response -> parseTokenCountResponse(request, response));
+    }
+
+    public Mono<LearningEmbeddingResponseDto> embedTexts(LearningEmbeddingRequestDto request) {
+        int totalCharacters = request.getInputs().stream().mapToInt(String::length).sum();
+        if (totalCharacters > MAX_EMBEDDING_INPUT_CHARACTERS) {
+            throw new CustomException("Embedding inputs may contain at most 2000 characters in total", HttpStatus.BAD_REQUEST);
+        }
+
+        Map<String, Object> upstreamRequest = Map.of(
+                "model", request.getModel(),
+                "input", request.getInputs(),
+                "truncate", false
+        );
+
+        return postJson("/api/embed", upstreamRequest)
+                .map(response -> parseEmbeddingResponse(request, response));
+    }
+
+    private Mono<JsonNode> postJson(String uri, Map<String, Object> upstreamRequest) {
+        return ollamaWebClient.post()
+                .uri(uri)
+                .bodyValue(upstreamRequest)
+                .retrieve()
+                .bodyToMono(String.class)
+                .switchIfEmpty(Mono.error(unsupportedLearningResponse()))
+                .map(this::readResponse);
+    }
+
+    private JsonNode readResponse(String responseBody) {
+        try {
+            return objectMapper.readTree(responseBody);
+        } catch (JacksonException exception) {
+            throw new CustomException("Ollama returned an invalid JSON response", HttpStatus.BAD_GATEWAY, exception);
+        }
+    }
+
+    LearningNextTokenResponseDto parseResponse(LearningNextTokenRequestDto request, JsonNode response) {
+        JsonNode logprobs = response.path("logprobs");
+        if (!logprobs.isArray() || logprobs.size() == 0) {
+            throw unsupportedLogprobs();
+        }
+
+        JsonNode firstPosition = logprobs.get(0);
+        String generatedToken = firstPosition.path("token").asString(response.path("response").asString(""));
+        Map<String, Double> tokenLogprobs = new LinkedHashMap<>();
+
+        JsonNode topLogprobs = firstPosition.path("top_logprobs");
+        if (topLogprobs.isArray()) {
+            topLogprobs.forEach(candidate -> addCandidate(tokenLogprobs, candidate));
+        }
+        addCandidate(tokenLogprobs, firstPosition);
+
+        List<Map.Entry<String, Double>> validCandidates = tokenLogprobs.entrySet().stream()
+                .filter(entry -> Double.isFinite(entry.getValue()))
+                .sorted(Map.Entry.<String, Double>comparingByValue(Comparator.reverseOrder()))
+                .limit(request.getTopK())
+                .toList();
+
+        if (validCandidates.isEmpty()) {
+            throw unsupportedLogprobs();
+        }
+
+        List<Double> rawProbabilities = validCandidates.stream()
+                .map(entry -> Math.exp(entry.getValue()))
+                .toList();
+        double mass = rawProbabilities.stream()
+                .filter(Double::isFinite)
+                .mapToDouble(Double::doubleValue)
+                .sum();
+        if (!Double.isFinite(mass) || mass <= 0d) {
+            throw unsupportedLogprobs();
+        }
+
+        List<LearningNextTokenCandidateDto> candidates = new ArrayList<>(validCandidates.size());
+        for (int index = 0; index < validCandidates.size(); index++) {
+            Map.Entry<String, Double> candidate = validCandidates.get(index);
+            double probability = rawProbabilities.get(index);
+            candidates.add(LearningNextTokenCandidateDto.builder()
+                    .token(candidate.getKey())
+                    .rank(index + 1)
+                    .logprob(candidate.getValue())
+                    .probability(probability)
+                    .normalizedProbability(probability / mass)
+                    .build());
+        }
+
+        double displayMass = Math.min(Math.max(mass, 0d), 1d);
+        return LearningNextTokenResponseDto.builder()
+                .source(SOURCE)
+                .modelLabel(response.path("model").asString(request.getModel()))
+                .prompt(request.getPrompt())
+                .generatedToken(generatedToken)
+                .capturedProbabilityMass(displayMass)
+                .truncated(displayMass < COMPLETE_MASS_THRESHOLD)
+                .candidates(candidates)
+                .build();
+    }
+
+    LearningTokenCountResponseDto parseTokenCountResponse(LearningTokenCountRequestDto request, JsonNode response) {
+        JsonNode countNode = response.get("prompt_eval_count");
+        if (countNode == null || !countNode.isIntegralNumber() || !countNode.canConvertToInt()
+                || countNode.intValue() < 1) {
+            throw new CustomException(
+                    "The selected model or Ollama runtime did not return a prompt token count",
+                    HttpStatus.UNPROCESSABLE_CONTENT
+            );
+        }
+
+        return LearningTokenCountResponseDto.builder()
+                .source(SOURCE)
+                .modelLabel(response.path("model").asString(request.getModel()))
+                .prompt(request.getPrompt())
+                .promptTokenCount(countNode.intValue())
+                .generatedToken(response.path("response").asString(""))
+                .build();
+    }
+
+    LearningEmbeddingResponseDto parseEmbeddingResponse(LearningEmbeddingRequestDto request, JsonNode response) {
+        JsonNode embeddingsNode = response.path("embeddings");
+        JsonNode countNode = response.get("prompt_eval_count");
+        if (!embeddingsNode.isArray() || embeddingsNode.size() != request.getInputs().size()
+                || countNode == null || !countNode.isIntegralNumber() || !countNode.canConvertToInt()
+                || countNode.intValue() < 1) {
+            throw unsupportedEmbeddingResponse();
+        }
+
+        List<List<Double>> vectors = new ArrayList<>(embeddingsNode.size());
+        int dimensions = -1;
+        for (JsonNode vectorNode : embeddingsNode) {
+            if (!vectorNode.isArray() || vectorNode.size() < 1 || vectorNode.size() > MAX_EMBEDDING_DIMENSIONS) {
+                throw unsupportedEmbeddingResponse();
+            }
+            if (dimensions < 0) {
+                dimensions = vectorNode.size();
+            } else if (vectorNode.size() != dimensions) {
+                throw unsupportedEmbeddingResponse();
+            }
+
+            List<Double> vector = new ArrayList<>(dimensions);
+            for (JsonNode valueNode : vectorNode) {
+                if (!valueNode.isNumber() || !Double.isFinite(valueNode.doubleValue())) {
+                    throw unsupportedEmbeddingResponse();
+                }
+                vector.add(valueNode.doubleValue());
+            }
+            vectors.add(List.copyOf(vector));
+        }
+
+        return LearningEmbeddingResponseDto.builder()
+                .source(SOURCE)
+                .modelLabel(response.path("model").asString(request.getModel()))
+                .dimensions(dimensions)
+                .promptTokenCount(countNode.intValue())
+                .vectors(List.copyOf(vectors))
+                .build();
+    }
+
+    private static void addCandidate(Map<String, Double> tokenLogprobs, JsonNode candidate) {
+        JsonNode tokenNode = candidate.get("token");
+        JsonNode logprobNode = candidate.get("logprob");
+        if (tokenNode == null || !tokenNode.isString() || logprobNode == null || !logprobNode.isNumber()) {
+            return;
+        }
+
+        double logprob = logprobNode.doubleValue();
+        if (!Double.isFinite(logprob)) {
+            return;
+        }
+        tokenLogprobs.merge(tokenNode.stringValue(), logprob, Math::max);
+    }
+
+    private static CustomException unsupportedLogprobs() {
+        return new CustomException(
+                "The selected model or Ollama runtime did not return next-token log probabilities",
+                HttpStatus.UNPROCESSABLE_CONTENT
+        );
+    }
+
+    private static CustomException unsupportedLearningResponse() {
+        return new CustomException("Ollama returned an empty learning response", HttpStatus.UNPROCESSABLE_CONTENT);
+    }
+
+    private static CustomException unsupportedEmbeddingResponse() {
+        return new CustomException(
+                "The selected model or Ollama runtime did not return valid text embeddings",
+                HttpStatus.UNPROCESSABLE_CONTENT
+        );
+    }
+}

--- a/src/test/java/com/awesome/testing/controller/exception/OllamaExceptionHandlerTest.java
+++ b/src/test/java/com/awesome/testing/controller/exception/OllamaExceptionHandlerTest.java
@@ -1,9 +1,11 @@
 package com.awesome.testing.controller.exception;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import java.nio.charset.StandardCharsets;
@@ -50,6 +52,18 @@ class OllamaExceptionHandlerTest {
     }
 
     @Test
+    void shouldDescribeAnUnavailableLocalOllamaService() {
+        WebClientRequestException exception = mock(WebClientRequestException.class);
+
+        ResponseEntity<OllamaExceptionHandler.ErrorResponse> response =
+                handler.handleWebClientRequestException(exception);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().message()).contains("Start the local Ollama service");
+    }
+
+    @Test
     void shouldHandleHttpMessageNotReadableException() {
         HttpMessageNotReadableException exception = mock(HttpMessageNotReadableException.class);
         RuntimeException cause = new RuntimeException("Unexpected character");
@@ -67,6 +81,5 @@ class OllamaExceptionHandlerTest {
         assertThat(response.getBody().timestamp()).isNotNull();
     }
 }
-
 
 

--- a/src/test/java/com/awesome/testing/endpoints/gpt2/Gpt2InspectorControllerTest.java
+++ b/src/test/java/com/awesome/testing/endpoints/gpt2/Gpt2InspectorControllerTest.java
@@ -1,0 +1,107 @@
+package com.awesome.testing.endpoints.gpt2;
+
+import com.awesome.testing.DomainHelper;
+import com.awesome.testing.dto.gpt2.Gpt2InspectorStatusDto;
+import com.awesome.testing.dto.gpt2.Gpt2TraceRequestDto;
+import com.awesome.testing.dto.user.Role;
+import com.awesome.testing.dto.user.UserRegisterDto;
+import com.awesome.testing.service.gpt2.Gpt2InspectorService;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.awesome.testing.factory.UserFactory.getRandomUserWithRoles;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class Gpt2InspectorControllerTest extends DomainHelper {
+
+    private static final String STATUS_ENDPOINT = "/api/v1/learning/gpt2/status";
+    private static final String TRACE_ENDPOINT = "/api/v1/learning/gpt2/trace";
+
+    @MockitoBean
+    private Gpt2InspectorService inspectorService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private String authToken;
+
+    @BeforeAll
+    void initAuthToken() {
+        UserRegisterDto user = getRandomUserWithRoles(List.of(Role.ROLE_CLIENT));
+        authToken = getToken(user);
+    }
+
+    @Test
+    void requiresAuthenticationForInspectorDiscovery() {
+        ResponseEntity<String> response = executeGet(
+                STATUS_ENDPOINT, getJsonOnlyHeaders(), String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void returnsInspectorAvailabilityToAnAuthenticatedLearner() {
+        when(inspectorService.status()).thenReturn(Gpt2InspectorStatusDto.builder()
+                .available(true)
+                .mode("full-local")
+                .message("Real GPT-2 activations are ready")
+                .modelLabel("openai-community/gpt2")
+                .build());
+
+        ResponseEntity<Gpt2InspectorStatusDto> response = executeGet(
+                STATUS_ENDPOINT, getHeadersWith(authToken), Gpt2InspectorStatusDto.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().isAvailable()).isTrue();
+        assertThat(response.getBody().getMode()).isEqualTo("full-local");
+    }
+
+    @Test
+    void validatesTraceInputBeforeCallingTheInspector() {
+        Gpt2TraceRequestDto request = Gpt2TraceRequestDto.builder()
+                .prompt(" ")
+                .layer(12)
+                .head(-1)
+                .selectedTokenIndex(32)
+                .build();
+
+        ResponseEntity<Map> response = executePost(
+                TRACE_ENDPOINT, request, getHeadersWith(authToken), Map.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).containsKeys("prompt", "layer", "head", "selectedTokenIndex");
+    }
+
+    @Test
+    void forwardsAValidAuthenticatedTraceRequest() throws Exception {
+        JsonNode trace = objectMapper.readTree("{\"source\":\"gpt2-live\",\"layer\":2}");
+        when(inspectorService.trace(any(Gpt2TraceRequestDto.class))).thenReturn(trace);
+        Gpt2TraceRequestDto request = Gpt2TraceRequestDto.builder()
+                .prompt("The animal was too")
+                .layer(2)
+                .head(4)
+                .selectedTokenIndex(3)
+                .build();
+
+        ResponseEntity<JsonNode> response = executePost(
+                TRACE_ENDPOINT, request, getHeadersWith(authToken), JsonNode.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().path("source").asString()).isEqualTo("gpt2-live");
+    }
+}

--- a/src/test/java/com/awesome/testing/endpoints/ollama/OllamaLearningControllerTest.java
+++ b/src/test/java/com/awesome/testing/endpoints/ollama/OllamaLearningControllerTest.java
@@ -1,0 +1,226 @@
+package com.awesome.testing.endpoints.ollama;
+
+import com.awesome.testing.dto.ollama.LearningNextTokenRequestDto;
+import com.awesome.testing.dto.ollama.LearningNextTokenResponseDto;
+import com.awesome.testing.dto.ollama.LearningEmbeddingRequestDto;
+import com.awesome.testing.dto.ollama.LearningEmbeddingResponseDto;
+import com.awesome.testing.dto.ollama.LearningTokenCountRequestDto;
+import com.awesome.testing.dto.ollama.LearningTokenCountResponseDto;
+import com.awesome.testing.dto.user.Role;
+import com.awesome.testing.dto.user.UserRegisterDto;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.awesome.testing.factory.UserFactory.getRandomUserWithRoles;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Tag("integration")
+class OllamaLearningControllerTest extends AbstractOllamaTest {
+
+    private static final String ENDPOINT = "/api/v1/ollama/learning/next-token";
+    private static final String TOKEN_COUNT_ENDPOINT = "/api/v1/ollama/learning/token-count";
+    private static final String EMBEDDINGS_ENDPOINT = "/api/v1/ollama/learning/embeddings";
+    private String authToken;
+
+    @BeforeAll
+    void initAuthToken() {
+        UserRegisterDto user = getRandomUserWithRoles(List.of(Role.ROLE_CLIENT));
+        authToken = getToken(user);
+    }
+
+    @Test
+    void returnsLiveDistributionAndSendsOneRawTokenRequest() {
+        OllamaMock.stubSuccessfulNextTokenLogprobs();
+
+        ResponseEntity<LearningNextTokenResponseDto> response = executePost(
+                ENDPOINT, validRequest(), getHeadersWith(authToken), LearningNextTokenResponseDto.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getSource()).isEqualTo("ollama-live");
+        assertThat(response.getBody().getCandidates()).hasSize(3);
+        assertThat(response.getBody().getCandidates().getFirst().getToken()).isEqualTo(" Paris");
+
+        verify(postRequestedFor(urlEqualTo("/api/generate"))
+                .withRequestBody(matchingJsonPath("$.model", equalTo("llama3.2:1b")))
+                .withRequestBody(matchingJsonPath("$.prompt", equalTo("The capital of France is")))
+                .withRequestBody(matchingJsonPath("$.stream", equalTo("false")))
+                .withRequestBody(matchingJsonPath("$.raw", equalTo("true")))
+                .withRequestBody(matchingJsonPath("$.logprobs", equalTo("true")))
+                .withRequestBody(matchingJsonPath("$.top_logprobs", equalTo("3")))
+                .withRequestBody(matchingJsonPath("$.options.num_predict", equalTo("1"))));
+    }
+
+    @Test
+    void rejectsInvalidRequestBeforeCallingOllama() {
+        LearningNextTokenRequestDto request = LearningNextTokenRequestDto.builder()
+                .model(" ")
+                .prompt("")
+                .topK(1)
+                .build();
+
+        ResponseEntity<Map> response = executePost(ENDPOINT, request, getHeadersWith(authToken), Map.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).containsKeys("model", "prompt", "topK");
+    }
+
+    @Test
+    void requiresAuthentication() {
+        ResponseEntity<String> response = executePost(ENDPOINT, validRequest(), getJsonOnlyHeaders(), String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void requiresAuthenticationForTheNewLanguageFoundationEndpoints() {
+        LearningTokenCountRequestDto tokenCountRequest = LearningTokenCountRequestDto.builder()
+                .model("bonsai")
+                .prompt("hello")
+                .build();
+
+        ResponseEntity<String> tokenCountResponse = executePost(
+                TOKEN_COUNT_ENDPOINT, tokenCountRequest, getJsonOnlyHeaders(), String.class);
+        ResponseEntity<String> embeddingsResponse = executePost(
+                EMBEDDINGS_ENDPOINT, embeddingRequest(), getJsonOnlyHeaders(), String.class);
+
+        assertThat(tokenCountResponse.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(embeddingsResponse.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void reportsUnsupportedLogprobs() {
+        OllamaMock.stubMissingNextTokenLogprobs();
+
+        ResponseEntity<Map> response = executePost(ENDPOINT, validRequest(), getHeadersWith(authToken), Map.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_CONTENT);
+        assertThat(response.getBody().get("message").toString()).contains("did not return next-token log probabilities");
+    }
+
+    @Test
+    void reportsAnEmptyUpstreamResponseAsUnsupportedLogprobs() {
+        OllamaMock.stubEmptyNextTokenResponse();
+
+        ResponseEntity<Map> response = executePost(ENDPOINT, validRequest(), getHeadersWith(authToken), Map.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_CONTENT);
+        assertThat(response.getBody().get("message").toString()).contains("did not return next-token log probabilities");
+    }
+
+    @Test
+    void verifiesPromptTokenCountWithOneRawGenerationStep() {
+        OllamaMock.stubSuccessfulTokenCount();
+        LearningTokenCountRequestDto request = LearningTokenCountRequestDto.builder()
+                .model("hf.co/prism-ml/Bonsai-27B-gguf:Q1_0")
+                .prompt("Tokenization turns text into pieces.")
+                .build();
+
+        ResponseEntity<LearningTokenCountResponseDto> response = executePost(
+                TOKEN_COUNT_ENDPOINT, request, getHeadersWith(authToken), LearningTokenCountResponseDto.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getPromptTokenCount()).isEqualTo(7);
+        assertThat(response.getBody().getGeneratedToken()).isEqualTo(" pieces");
+        verify(postRequestedFor(urlEqualTo("/api/generate"))
+                .withRequestBody(matchingJsonPath("$.raw", equalTo("true")))
+                .withRequestBody(matchingJsonPath("$.stream", equalTo("false")))
+                .withRequestBody(matchingJsonPath("$.logprobs", equalTo("true")))
+                .withRequestBody(matchingJsonPath("$.top_logprobs", equalTo("1")))
+                .withRequestBody(matchingJsonPath("$.options.num_predict", equalTo("1"))));
+    }
+
+    @Test
+    void reportsMissingPromptTokenCount() {
+        OllamaMock.stubMissingTokenCount();
+        LearningTokenCountRequestDto request = LearningTokenCountRequestDto.builder()
+                .model("hf.co/prism-ml/Bonsai-27B-gguf:Q1_0")
+                .prompt("Tokenization turns text into pieces.")
+                .build();
+
+        ResponseEntity<Map> response = executePost(
+                TOKEN_COUNT_ENDPOINT, request, getHeadersWith(authToken), Map.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_CONTENT);
+        assertThat(response.getBody().get("message").toString()).contains("did not return a prompt token count");
+    }
+
+    @Test
+    void returnsValidatedEmbeddingVectors() {
+        OllamaMock.stubSuccessfulEmbeddings();
+        LearningEmbeddingRequestDto request = embeddingRequest();
+
+        ResponseEntity<LearningEmbeddingResponseDto> response = executePost(
+                EMBEDDINGS_ENDPOINT, request, getHeadersWith(authToken), LearningEmbeddingResponseDto.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getModelLabel()).isEqualTo("embeddinggemma");
+        assertThat(response.getBody().getDimensions()).isEqualTo(4);
+        assertThat(response.getBody().getPromptTokenCount()).isEqualTo(19);
+        assertThat(response.getBody().getVectors()).hasSize(3).allSatisfy(vector -> assertThat(vector).hasSize(4));
+        verify(postRequestedFor(urlEqualTo("/api/embed"))
+                .withRequestBody(matchingJsonPath("$.model", equalTo("embeddinggemma")))
+                .withRequestBody(matchingJsonPath("$.input[0]", equalTo("A puppy is playing outside.")))
+                .withRequestBody(matchingJsonPath("$.truncate", equalTo("false"))));
+    }
+
+    @Test
+    void rejectsAnEmbeddingResponseThatDoesNotMatchTheInputCount() {
+        OllamaMock.stubInvalidEmbeddings();
+
+        ResponseEntity<Map> response = executePost(
+                EMBEDDINGS_ENDPOINT, embeddingRequest(), getHeadersWith(authToken), Map.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_CONTENT);
+        assertThat(response.getBody().get("message").toString()).contains("did not return valid text embeddings");
+    }
+
+    @Test
+    void rejectsTooMuchEmbeddingTextBeforeCallingOllama() {
+        String longInput = "x".repeat(500);
+        LearningEmbeddingRequestDto request = LearningEmbeddingRequestDto.builder()
+                .model("embeddinggemma")
+                .inputs(List.of(longInput, longInput, longInput, longInput, longInput))
+                .build();
+
+        ResponseEntity<Map> response = executePost(
+                EMBEDDINGS_ENDPOINT, request, getHeadersWith(authToken), Map.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().get("message").toString()).contains("at most 2000 characters in total");
+    }
+
+    private static LearningNextTokenRequestDto validRequest() {
+        return LearningNextTokenRequestDto.builder()
+                .model("llama3.2:1b")
+                .prompt("The capital of France is")
+                .topK(3)
+                .build();
+    }
+
+    private static LearningEmbeddingRequestDto embeddingRequest() {
+        return LearningEmbeddingRequestDto.builder()
+                .model("embeddinggemma")
+                .inputs(List.of(
+                        "A puppy is playing outside.",
+                        "A dog runs through the park.",
+                        "The database migration failed."
+                ))
+                .build();
+    }
+}

--- a/src/test/java/com/awesome/testing/endpoints/ollama/OllamaMock.java
+++ b/src/test/java/com/awesome/testing/endpoints/ollama/OllamaMock.java
@@ -53,6 +53,94 @@ public class OllamaMock {
                 ));
     }
 
+    public static void stubSuccessfulNextTokenLogprobs() {
+        stubFor(post(urlEqualTo("/api/generate"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {
+                                  "model":"llama3.2:1b",
+                                  "response":" Paris",
+                                  "done":true,
+                                  "logprobs":[{
+                                    "token":" Paris",
+                                    "logprob":-0.2,
+                                    "bytes":[32,80,97,114,105,115],
+                                    "top_logprobs":[
+                                      {"token":" Paris","logprob":-0.2},
+                                      {"token":" Lyon","logprob":-1.6},
+                                      {"token":" London","logprob":-2.2}
+                                    ]
+                                  }]
+                                }
+                                """)));
+    }
+
+    public static void stubMissingNextTokenLogprobs() {
+        stubFor(post(urlEqualTo("/api/generate"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {"model":"llama3.2:1b","response":" Paris","done":true,"logprobs":null}
+                                """)));
+    }
+
+    public static void stubEmptyNextTokenResponse() {
+        stubFor(post(urlEqualTo("/api/generate"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("")));
+    }
+
+    public static void stubSuccessfulTokenCount() {
+        stubFor(post(urlEqualTo("/api/generate"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {
+                                  "model":"hf.co/prism-ml/Bonsai-27B-gguf:Q1_0",
+                                  "response":" pieces",
+                                  "done":true,
+                                  "prompt_eval_count":7
+                                }
+                                """)));
+    }
+
+    public static void stubMissingTokenCount() {
+        stubFor(post(urlEqualTo("/api/generate"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {"model":"hf.co/prism-ml/Bonsai-27B-gguf:Q1_0","response":" pieces","done":true}
+                                """)));
+    }
+
+    public static void stubSuccessfulEmbeddings() {
+        stubFor(post(urlEqualTo("/api/embed"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {
+                                  "model":"embeddinggemma",
+                                  "embeddings":[
+                                    [0.8,0.4,0.2,0.1],
+                                    [0.75,0.45,0.18,0.12],
+                                    [-0.2,0.1,0.8,0.5]
+                                  ],
+                                  "prompt_eval_count":19
+                                }
+                                """)));
+    }
+
+    public static void stubInvalidEmbeddings() {
+        stubFor(post(urlEqualTo("/api/embed"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {"model":"embeddinggemma","embeddings":[[0.8],[0.7]],"prompt_eval_count":4}
+                                """)));
+    }
+
     // api/chat
     public static void stubSuccessfulChat() {
         stubFor(post(urlEqualTo("/api/chat"))

--- a/src/test/java/com/awesome/testing/service/gpt2/Gpt2InspectorServiceTest.java
+++ b/src/test/java/com/awesome/testing/service/gpt2/Gpt2InspectorServiceTest.java
@@ -1,0 +1,143 @@
+package com.awesome.testing.service.gpt2;
+
+import com.awesome.testing.controller.exception.CustomException;
+import com.awesome.testing.dto.gpt2.Gpt2EmbeddingSpaceRequestDto;
+import com.awesome.testing.dto.gpt2.Gpt2InspectorStatusDto;
+import com.awesome.testing.dto.gpt2.Gpt2TraceRequestDto;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.JsonNode;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class Gpt2InspectorServiceTest {
+
+    private HttpServer server;
+    private Gpt2InspectorService service;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.start();
+        service = new Gpt2InspectorService();
+        ReflectionTestUtils.setField(service, "baseUrl", "http://127.0.0.1:" + server.getAddress().getPort());
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop(0);
+    }
+
+    @Test
+    void reportsReadyInspectorMetadata() {
+        respond("/health", 200, """
+                {"status":"ready","modelLabel":"openai-community/gpt2","modelRevision":"607a30d7",
+                 "layerCount":12,"headCount":12,"maxTokens":32}
+                """);
+
+        Gpt2InspectorStatusDto result = service.status();
+
+        assertThat(result.isAvailable()).isTrue();
+        assertThat(result.getMode()).isEqualTo("full-local");
+        assertThat(result.getModelRevision()).isEqualTo("607a30d7");
+        assertThat(result.getLayerCount()).isEqualTo(12);
+        assertThat(result.getHeadCount()).isEqualTo(12);
+        assertThat(result.getMaxTokens()).isEqualTo(32);
+    }
+
+    @Test
+    void treatsAnUnhealthySidecarAsUnavailable() {
+        respond("/health", 503, "{\"detail\":\"GPT-2 is still loading\"}");
+
+        Gpt2InspectorStatusDto result = service.status();
+
+        assertThat(result.isAvailable()).isFalse();
+        assertThat(result.getMessage()).contains("starting or unavailable");
+    }
+
+    @Test
+    void forwardsAValidatedTraceRequest() {
+        AtomicReference<String> requestBody = respond("/trace", 200, "{\"source\":\"gpt2-live\",\"layer\":3}");
+        Gpt2TraceRequestDto request = Gpt2TraceRequestDto.builder()
+                .prompt("The animal was too")
+                .layer(3)
+                .head(2)
+                .selectedTokenIndex(3)
+                .build();
+
+        JsonNode result = service.trace(request);
+
+        assertThat(result.path("source").asString()).isEqualTo("gpt2-live");
+        assertThat(requestBody.get()).contains("\"prompt\":\"The animal was too\"")
+                .contains("\"layer\":3")
+                .contains("\"head\":2")
+                .contains("\"selectedTokenIndex\":3");
+    }
+
+    @Test
+    void rejectsAnEmptyEmbeddingSelectorWithoutCallingTheSidecar() {
+        Gpt2EmbeddingSpaceRequestDto request = Gpt2EmbeddingSpaceRequestDto.builder().build();
+
+        assertThatThrownBy(() -> service.embeddingSpace(request))
+                .isInstanceOfSatisfying(CustomException.class, exception -> {
+                    assertThat(exception.getHttpStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+                    assertThat(exception.getMessage()).contains("query or tokenId");
+                });
+    }
+
+    @Test
+    void preservesControlledSidecarRejectionsAsBadRequests() {
+        respond("/trace", 400, "{\"detail\":\"Prompt may contain at most 32 GPT-2 tokens\"}");
+        Gpt2TraceRequestDto request = Gpt2TraceRequestDto.builder()
+                .prompt("A prompt that the sidecar rejects")
+                .build();
+
+        assertThatThrownBy(() -> service.trace(request))
+                .isInstanceOfSatisfying(CustomException.class, exception -> {
+                    assertThat(exception.getHttpStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+                    assertThat(exception.getMessage()).contains("rejected the trace request");
+                    assertThat(exception.getMessage()).doesNotContain("32 GPT-2 tokens");
+                });
+    }
+
+    @Test
+    void refusesInspectionWhenThePrivateSidecarIsNotConfigured() {
+        ReflectionTestUtils.setField(service, "baseUrl", " ");
+        Gpt2TraceRequestDto request = Gpt2TraceRequestDto.builder().prompt("hello").build();
+
+        assertThatThrownBy(() -> service.trace(request))
+                .isInstanceOfSatisfying(CustomException.class, exception ->
+                        assertThat(exception.getHttpStatus()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE));
+    }
+
+    private AtomicReference<String> respond(String path, int status, String responseBody) {
+        AtomicReference<String> requestBody = new AtomicReference<>();
+        server.createContext(path, exchange -> writeResponse(exchange, status, responseBody, requestBody));
+        return requestBody;
+    }
+
+    private static void writeResponse(
+            HttpExchange exchange,
+            int status,
+            String responseBody,
+            AtomicReference<String> requestBody
+    ) throws IOException {
+        requestBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+        byte[] response = responseBody.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, response.length);
+        exchange.getResponseBody().write(response);
+        exchange.close();
+    }
+}

--- a/src/test/java/com/awesome/testing/service/ollama/OllamaLearningServiceTest.java
+++ b/src/test/java/com/awesome/testing/service/ollama/OllamaLearningServiceTest.java
@@ -1,0 +1,147 @@
+package com.awesome.testing.service.ollama;
+
+import com.awesome.testing.controller.exception.CustomException;
+import com.awesome.testing.dto.ollama.LearningNextTokenRequestDto;
+import com.awesome.testing.dto.ollama.LearningNextTokenResponseDto;
+import com.awesome.testing.dto.ollama.LearningEmbeddingRequestDto;
+import com.awesome.testing.dto.ollama.LearningEmbeddingResponseDto;
+import com.awesome.testing.dto.ollama.LearningTokenCountRequestDto;
+import com.awesome.testing.dto.ollama.LearningTokenCountResponseDto;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+class OllamaLearningServiceTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final OllamaLearningService service = new OllamaLearningService(mock(WebClient.class), objectMapper);
+
+    @Test
+    void parsesSortsDeduplicatesAndNormalizesModernLogprobs() throws Exception {
+        LearningNextTokenRequestDto request = request(3);
+        JsonNode response = objectMapper.readTree("""
+                {
+                  "model": "llama3.2:1b",
+                  "response": " Paris",
+                  "logprobs": [{
+                    "token": " Paris",
+                    "logprob": -0.3,
+                    "top_logprobs": [
+                      {"token": " Lyon", "logprob": -3.0},
+                      {"token": " Paris", "logprob": -0.4},
+                      {"token": " London", "logprob": -2.0},
+                      {"token": " Berlin", "logprob": -4.0}
+                    ]
+                  }]
+                }
+                """);
+
+        LearningNextTokenResponseDto result = service.parseResponse(request, response);
+
+        assertThat(result.getSource()).isEqualTo("ollama-live");
+        assertThat(result.getGeneratedToken()).isEqualTo(" Paris");
+        assertThat(result.getCandidates()).extracting(candidate -> candidate.getToken())
+                .containsExactly(" Paris", " London", " Lyon");
+        assertThat(result.getCandidates()).extracting(candidate -> candidate.getRank())
+                .containsExactly(1, 2, 3);
+        assertThat(result.getCandidates().getFirst().getLogprob()).isEqualTo(-0.3d);
+        assertThat(result.getCandidates()).allSatisfy(candidate -> {
+            assertThat(candidate.getProbability()).isFinite().isPositive();
+            assertThat(candidate.getNormalizedProbability()).isFinite().isPositive();
+        });
+        assertThat(result.getCandidates().stream().mapToDouble(candidate -> candidate.getNormalizedProbability()).sum())
+                .isCloseTo(1d, org.assertj.core.data.Offset.offset(1e-12));
+        assertThat(result.isTruncated()).isTrue();
+    }
+
+    @Test
+    void usesGeneratedPositionWhenTopCandidatesAreAbsent() throws Exception {
+        JsonNode response = objectMapper.readTree("""
+                {"response":"!","logprobs":[{"token":"!","logprob":0.0}]}
+                """);
+
+        LearningNextTokenResponseDto result = service.parseResponse(request(10), response);
+
+        assertThat(result.getCandidates()).hasSize(1);
+        assertThat(result.getCandidates().getFirst().getProbability()).isEqualTo(1d);
+        assertThat(result.isTruncated()).isFalse();
+    }
+
+    @Test
+    void rejectsMissingLogprobsWithUsefulStatus() throws Exception {
+        JsonNode response = objectMapper.readTree("{\"response\":\" Paris\",\"logprobs\":null}");
+
+        assertThatThrownBy(() -> service.parseResponse(request(10), response))
+                .isInstanceOfSatisfying(CustomException.class, exception -> {
+                    assertThat(exception.getHttpStatus()).isEqualTo(HttpStatus.UNPROCESSABLE_CONTENT);
+                    assertThat(exception.getMessage()).contains("did not return next-token log probabilities");
+                });
+    }
+
+    @Test
+    void parsesPromptTokenCountAndGeneratedEvidence() throws Exception {
+        LearningTokenCountRequestDto request = LearningTokenCountRequestDto.builder()
+                .model("bonsai")
+                .prompt("A short prompt")
+                .build();
+        JsonNode response = objectMapper.readTree("""
+                {"model":"bonsai:latest","response":" continues","prompt_eval_count":4}
+                """);
+
+        LearningTokenCountResponseDto result = service.parseTokenCountResponse(request, response);
+
+        assertThat(result.getModelLabel()).isEqualTo("bonsai:latest");
+        assertThat(result.getPromptTokenCount()).isEqualTo(4);
+        assertThat(result.getGeneratedToken()).isEqualTo(" continues");
+    }
+
+    @Test
+    void parsesFiniteEqualLengthEmbeddingVectors() throws Exception {
+        LearningEmbeddingRequestDto request = embeddingRequest();
+        JsonNode response = objectMapper.readTree("""
+                {"model":"embeddinggemma","embeddings":[[0.8,0.4],[0.7,0.5]],"prompt_eval_count":8}
+                """);
+
+        LearningEmbeddingResponseDto result = service.parseEmbeddingResponse(request, response);
+
+        assertThat(result.getDimensions()).isEqualTo(2);
+        assertThat(result.getPromptTokenCount()).isEqualTo(8);
+        assertThat(result.getVectors()).containsExactly(List.of(0.8, 0.4), List.of(0.7, 0.5));
+    }
+
+    @Test
+    void rejectsNonFiniteOrRaggedEmbeddingVectors() throws Exception {
+        JsonNode response = objectMapper.readTree("""
+                {"embeddings":[[0.8,0.4],[0.7]],"prompt_eval_count":8}
+                """);
+
+        assertThatThrownBy(() -> service.parseEmbeddingResponse(embeddingRequest(), response))
+                .isInstanceOfSatisfying(CustomException.class, exception -> {
+                    assertThat(exception.getHttpStatus()).isEqualTo(HttpStatus.UNPROCESSABLE_CONTENT);
+                    assertThat(exception.getMessage()).contains("did not return valid text embeddings");
+                });
+    }
+
+    private static LearningNextTokenRequestDto request(int topK) {
+        return LearningNextTokenRequestDto.builder()
+                .model("llama3.2:1b")
+                .prompt("The capital of France is")
+                .topK(topK)
+                .build();
+    }
+
+    private static LearningEmbeddingRequestDto embeddingRequest() {
+        return LearningEmbeddingRequestDto.builder()
+                .model("embeddinggemma")
+                .inputs(List.of("one", "two"))
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- add authenticated, rate-limited Ollama learning endpoints for next-token probabilities, token counts, and embeddings
- add an optional hardened proxy for the full-local GPT-2 inspector
- validate inputs and upstream responses, bound response size and timeouts, and map failures safely

## Validation
- 422 unit tests with PMD and JaCoCo
- 32 integration tests
- non-root Docker image build
- real full-stack authenticated GPT-2 and Bonsai endpoint smokes

The unrelated JwtTokenFilter logging change is intentionally excluded.