### PR TITLE
Automate backend container publishing

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,210 @@
+name: Publish container image
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Immutable image tag, for example 3.8.0-rc.1
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+concurrency:
+  group: publish-backend-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  GHCR_IMAGE: ghcr.io/${{ github.repository }}
+  DOCKERHUB_IMAGE: docker.io/slawekradzyminski/backend
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v5.6.0
+        with:
+          java-version: '25'
+          distribution: temurin
+          cache: maven
+
+      - name: Validate release source and version
+        id: release
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_VERSION: ${{ inputs.version }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          git fetch --no-tags origin "$DEFAULT_BRANCH"
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" "origin/$DEFAULT_BRANCH"; then
+            echo "The release commit must belong to $DEFAULT_BRANCH." >&2
+            exit 1
+          fi
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$MANUAL_VERSION"
+          else
+            VERSION="${REF_NAME#v}"
+          fi
+          if ! printf '%s' "$VERSION" | grep --extended-regexp --quiet '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$'; then
+            echo "Version must look like 3.8.0 or 3.8.0-rc.1." >&2
+            exit 1
+          fi
+
+          PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+          case "$VERSION" in
+            "$PROJECT_VERSION"|"$PROJECT_VERSION"-*) ;;
+            *)
+              echo "Release $VERSION does not match Maven project version $PROJECT_VERSION." >&2
+              exit 1
+              ;;
+          esac
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  unit-tests:
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - uses: actions/setup-java@v5.6.0
+        with:
+          java-version: '25'
+          distribution: temurin
+          cache: maven
+      - run: ./mvnw clean verify
+
+  integration-tests:
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - uses: actions/setup-java@v5.6.0
+        with:
+          java-version: '25'
+          distribution: temurin
+          cache: maven
+      - run: ./mvnw -q -Pfast-verify,integration-tests verify
+
+  verify-local:
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - uses: actions/setup-java@v5.6.0
+        with:
+          java-version: '25'
+          distribution: temurin
+          cache: maven
+      - run: chmod +x scripts/verify-local.sh
+      - run: ./scripts/verify-local.sh
+      - name: Upload application log
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: release-app-log
+          path: app.log
+          retention-days: 7
+
+  verify-docker:
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - uses: actions/setup-java@v5.6.0
+        with:
+          java-version: '25'
+          distribution: temurin
+          cache: maven
+      - run: chmod +x scripts/verify-docker.sh
+      - run: ./scripts/verify-docker.sh
+      - name: Upload Docker log
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: release-docker-log
+          path: docker.log
+          retention-days: 7
+
+  publish:
+    needs: [validate, unit-tests, integration-tests, verify-local, verify-docker]
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7.0.0
+
+      - name: Validate Docker Hub credentials
+        env:
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        run: |
+          if [ -z "$DOCKERHUB_USERNAME" ] || [ -z "$DOCKERHUB_TOKEN" ]; then
+            echo "DOCKERHUB_USERNAME and DOCKERHUB_TOKEN repository secrets are required to publish." >&2
+            exit 1
+          fi
+
+      - uses: docker/setup-qemu-action@v4.2.0
+      - uses: docker/setup-buildx-action@v4.2.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4.4.0
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v6.2.0
+        with:
+          images: |
+            ${{ env.GHCR_IMAGE }}
+            ${{ env.DOCKERHUB_IMAGE }}
+          tags: |
+            type=raw,value=${{ needs.validate.outputs.version }}
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ needs.validate.outputs.version }}
+
+      - name: Build and publish multi-platform image
+        id: build
+        uses: docker/build-push-action@v7.3.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: mode=max
+          sbom: true
+
+      - name: Record published digest
+        run: echo "Published digest \`${{ steps.build.outputs.digest }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v7.0.0
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v5.5.0
+        uses: actions/setup-java@v5.6.0
         with:
           java-version: '25'
           distribution: 'temurin'
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v7.0.0
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v5.5.0
+        uses: actions/setup-java@v5.6.0
         with:
           java-version: '25'
           distribution: 'temurin'
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@v7.0.0
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v5.5.0
+        uses: actions/setup-java@v5.6.0
         with:
           java-version: '25'
           distribution: 'temurin'
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/checkout@v7.0.0
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v5.5.0
+        uses: actions/setup-java@v5.6.0
         with:
           java-version: '25'
           distribution: 'temurin'

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN --mount=type=cache,target=/root/.m2 \
 
 COPY src ./src
 RUN --mount=type=cache,target=/root/.m2 \
-    ./mvnw -B -Dmaven.test.skip=true clean package
+    ./mvnw -B -Dmaven.test.skip=true clean package \
+    && cp target/jwt-auth-service-*.jar app.jar
 
 FROM eclipse-temurin:25-jre-jammy
 WORKDIR /app
@@ -24,9 +25,9 @@ RUN apt-get update \
     && mkdir -p /app/logs \
     && chown app:app /app/logs \
     && rm -rf /var/lib/apt/lists/*
-COPY --from=build --chown=app:app /app/target/jwt-auth-service-1.0.0.jar .
+COPY --from=build --chown=app:app /app/app.jar .
 USER app
 EXPOSE 4001
 HEALTHCHECK --interval=30s --timeout=5s --start-period=180s --retries=3 \
     CMD curl --fail --silent --show-error http://localhost:4001/actuator/health || exit 1
-ENTRYPOINT ["java", "-jar", "jwt-auth-service-1.0.0.jar"]
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>murraco</groupId>
     <artifactId>jwt-auth-service</artifactId>
-    <version>3.7.10</version>
+    <version>3.7.11</version>
     <packaging>jar</packaging>
 
     <name>spring-boot-jwt</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>murraco</groupId>
     <artifactId>jwt-auth-service</artifactId>
-    <version>1.0.0</version>
+    <version>3.7.10</version>
     <packaging>jar</packaging>
 
     <name>spring-boot-jwt</name>


### PR DESCRIPTION
## What changed

- upgrade setup-java to the current Node 24-compatible action release
- add tag/manual dual GHCR and Docker Hub multi-platform publishing
- require default-branch ancestry and Maven-version validation
- preserve unit, integration, local-runtime, and Docker release gates
- add cache, SBOM, provenance, SHA/version tags, and digest summary
- align Maven metadata with release 3.7.10 and make the runtime JAR name version-independent

## Why

Backend images were previously published manually and the hard-coded JAR filename prevented reliable version validation.

## Validation

- fast Maven verification with 422 tests
- all existing release jobs retained
- Docker build
- actionlint and diff checks