### PR TITLE
Prepare 3.7.12 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>murraco</groupId>
     <artifactId>jwt-auth-service</artifactId>
-    <version>3.7.11</version>
+    <version>3.7.12</version>
     <packaging>jar</packaging>
 
     <name>spring-boot-jwt</name>


### PR DESCRIPTION
## What changed\n\n- bumps the backend release version to 3.7.12\n- creates a fresh immutable release for the coordinated compatibility set\n\n## Validation\n\n- ./mvnw -Pfast-verify verify (422 tests passed)\n\nAfter merge, tag the verified master commit as v3.7.12 to publish the multi-architecture image through GitHub Actions.