### PR TITLE
Update backend GitHub Actions dependencies

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -30,7 +30,7 @@ jobs:
     outputs:
       version: ${{ steps.release.outputs.version }}
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
 
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
       - uses: actions/setup-java@v5.6.0
         with:
           java-version: '25'
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
       - uses: actions/setup-java@v5.6.0
         with:
           java-version: '25'
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
       - uses: actions/setup-java@v5.6.0
         with:
           java-version: '25'
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
       - uses: actions/setup-java@v5.6.0
         with:
           java-version: '25'
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
 
       - name: Validate Docker Hub credentials
         env:
@@ -163,14 +163,14 @@ jobs:
       - uses: docker/setup-buildx-action@v4.2.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4.4.0
+        uses: docker/login-action@v4.5.1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4.4.0
+        uses: docker/login-action@v4.5.1
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -11,7 +11,7 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5.6.0
@@ -62,7 +62,7 @@ jobs:
   integration-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5.6.0
@@ -86,7 +86,7 @@ jobs:
   verify-local:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5.6.0
@@ -112,7 +112,7 @@ jobs:
   verify-docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5.6.0


### PR DESCRIPTION
## Summary

- update `actions/checkout` from 7.0.0 to 7.0.1
- update `docker/login-action` from 4.4.0 to 4.5.1

The Maven dependency and plugin audit found all explicitly declared backend dependencies and plugins already current, so no application dependency overrides were added.

## Validation

- `./mvnw -Pfast-verify verify` — 394 tests