### PR TITLE
Prepare backend 3.7.14 dependency refresh

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -163,14 +163,14 @@ jobs:
       - uses: docker/setup-buildx-action@v4.2.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4.5.1
+        uses: docker/login-action@v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4.5.1
+        uses: docker/login-action@v4.6.0
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM eclipse-temurin:25-jdk-jammy AS build
+FROM eclipse-temurin:25-jdk-jammy@sha256:0348e7b24ad4479cf35927b750671bb4b78465c303003b08536f6f2fa6f180cd AS build
 WORKDIR /app
 
 RUN apt-get update \
@@ -16,7 +16,7 @@ RUN --mount=type=cache,target=/root/.m2 \
     ./mvnw -B -Dmaven.test.skip=true clean package \
     && cp target/jwt-auth-service-*.jar app.jar
 
-FROM eclipse-temurin:25-jre-jammy
+FROM eclipse-temurin:25-jre-jammy@sha256:b8ba5fca9d88b6ecc3a46c8e75b744f84aca9a9d08587901b5ab480baf641ab5
 WORKDIR /app
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
   backend:
     build: .
-    platform: linux/amd64
     restart: always
     ports:
       - "4001:4001"
@@ -20,8 +19,7 @@ services:
       - my-private-ntwk
 
   postgres:
-    image: postgres:16.1
-    platform: linux/amd64
+    image: postgres:16.14-bookworm
     restart: always
     environment:
       POSTGRES_DB: testdb
@@ -35,29 +33,27 @@ services:
       - my-private-ntwk
     
   frontend:
-   image: slawekradzyminski/frontend:3.6.6
-   platform: linux/amd64
+   image: slawekradzyminski/frontend:3.7.11@sha256:b1c0bb05b1aaf5ca8e38552dcb137d8ba908975fa1c8c0eb7d80ca003afa03f8
    restart: always
    ports:
-     - "8081:8081"
+     - "8081:80"
    networks:
      - my-private-ntwk
 
   activemq:
-    image: apache/activemq-artemis:2.31.2
-    platform: linux/amd64
+    image: apache/artemis:2.55.0@sha256:a192eee9c46e6352625ca9dbf0beebe4a34c363111c628bbb10c4aff1227341d
     restart: always
     environment:
       ARTEMIS_USER: admin
       ARTEMIS_PASSWORD: admin
       ANONYMOUS_LOGIN: "true"
-      EXTRA_ARGS: --http-host 0.0.0.0 --relax-jolokia --no-autotune
-      DISABLE_SECURITY: true
-      BROKER_CONFIG_GLOBAL_MAX_SIZE: 512mb
+      EXTRA_ARGS: --http-host 0.0.0.0 --relax-jolokia --no-autotune --global-max-size 512M
     ports:
       - "61616:61616"
       - "8161:8161"
       - "5672:5672"
+    volumes:
+      - activemq-data:/var/lib/artemis-instance
     hostname: activemq
     networks:
       - my-private-ntwk
@@ -74,6 +70,7 @@ services:
       - my-private-ntwk
 
 volumes:
+  activemq-data:
   postgres-data:
   ollama-data:
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>murraco</groupId>
     <artifactId>jwt-auth-service</artifactId>
-    <version>3.7.13</version>
+    <version>3.7.14</version>
     <packaging>jar</packaging>
 
     <name>spring-boot-jwt</name>
@@ -16,12 +16,12 @@
         <start-class>com.awesome.testing.JwtAuthServiceApp</start-class>
         <skip.pmd>false</skip.pmd>
         <skip.jacoco>false</skip.jacoco>
-        <artemis.version>2.54.0</artemis.version>
+        <artemis.version>2.55.0</artemis.version>
         <caffeine.version>3.2.4</caffeine.version>
         <lombok.version>1.18.46</lombok.version>
         <mockito.version>5.23.0</mockito.version>
-        <postgresql.version>42.7.11</postgresql.version>
-        <reactor-bom.version>2025.0.5</reactor-bom.version>
+        <postgresql.version>42.7.13</postgresql.version>
+        <reactor-bom.version>2025.0.6</reactor-bom.version>
         <otp-java.version>2.2.0</otp-java.version>
     </properties>
 
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>org.zalando</groupId>
             <artifactId>logbook-spring-boot-starter</artifactId>
-            <version>4.0.4</version>
+            <version>4.1.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>


### PR DESCRIPTION
## What changed

Prepares backend `3.7.14`, updates Artemis, PostgreSQL JDBC, Reactor, and Logbook dependencies, pins Java 25 LTS Temurin build/runtime images to immutable digests, synchronizes the standalone Compose stack, and updates container publishing actions.

## Why

This keeps the backend aligned with the refreshed platform services and makes container builds reproducible while remaining on the latest Java LTS line.

## Impact

The release produces the backend image required by the central stack refresh. The application remains on Java 25 LTS; the pinned official Temurin containers currently contain 25.0.3+9.

## Validation

- `./mvnw -Pfast-verify verify`: 394 tests passed
- Multi-stage Docker image build passed
- Built runtime reports Temurin Java 25.0.3+9 LTS
- Standalone Compose configuration passed
- Full direct and proxied runtime smoke checks passed
- `git diff --check` passed