### PR TITLE
Harden backend build and development image pins

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - my-private-ntwk
 
   postgres:
-    image: postgres:16.14-bookworm
+    image: postgres:16.14-bookworm@sha256:92620daddcd947f8d5ab5ba66e848702fe443d87fed30c4cea8e389fd78dfc55
     restart: always
     environment:
       POSTGRES_DB: testdb
@@ -33,7 +33,7 @@ services:
       - my-private-ntwk
     
   frontend:
-   image: slawekradzyminski/frontend:3.7.11@sha256:b1c0bb05b1aaf5ca8e38552dcb137d8ba908975fa1c8c0eb7d80ca003afa03f8
+   image: slawekradzyminski/frontend:3.7.12@sha256:59acd367dca78a0aea8776467885eda39d56b8259906a0f110d7063e6ff7e112
    restart: always
    ports:
      - "8081:80"
@@ -59,7 +59,7 @@ services:
       - my-private-ntwk
 
   ollama:
-    image: slawekradzyminski/ollama-qwen35-2b:0.18.3
+    image: slawekradzyminski/ollama-qwen35-2b:0.18.3@sha256:e5f0c74f0d086459837cee887574869da1703a7dbefc3cbd2702eb26b73c1953
     container_name: ollama
     restart: unless-stopped
     ports:

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,29 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.6.3</version>
+                <executions>
+                    <execution>
+                        <id>enforce-build-runtime</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>[3.9.16,4.0.0)</version>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>[25,26)</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>

--- a/src/test/java/com/awesome/testing/migration/RefreshTokenMigrationIT.java
+++ b/src/test/java/com/awesome/testing/migration/RefreshTokenMigrationIT.java
@@ -11,11 +11,16 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
 
 class RefreshTokenMigrationIT {
 
     private static final PostgreSQLContainer POSTGRES =
-            new PostgreSQLContainer("postgres:16-alpine");
+            new PostgreSQLContainer(
+                    DockerImageName.parse(
+                                    "postgres:16-alpine@sha256:"
+                                            + "57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777")
+                            .asCompatibleSubstituteFor("postgres"));
 
     @BeforeAll
     static void startPostgres() {

--- a/src/test/java/com/awesome/testing/repository/PasswordResetTokenConcurrencyIT.java
+++ b/src/test/java/com/awesome/testing/repository/PasswordResetTokenConcurrencyIT.java
@@ -24,6 +24,7 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
 
 @DataJpaTest(showSql = false, properties = {
         "spring.jpa.hibernate.ddl-auto=validate",
@@ -34,7 +35,11 @@ import org.testcontainers.postgresql.PostgreSQLContainer;
 class PasswordResetTokenConcurrencyIT {
 
     private static final PostgreSQLContainer POSTGRES =
-            new PostgreSQLContainer("postgres:16-alpine");
+            new PostgreSQLContainer(
+                    DockerImageName.parse(
+                                    "postgres:16-alpine@sha256:"
+                                            + "57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777")
+                            .asCompatibleSubstituteFor("postgres"));
 
     static {
         POSTGRES.start();


### PR DESCRIPTION
## Summary
- require Maven 3.9.16 and Java 25 with Maven Enforcer
- refresh the frontend development image and pin Postgres/Ollama images by digest
- pin Testcontainers Postgres and declare official-image compatibility

## Verification
- `./mvnw verify`
- `./mvnw -Pintegration-tests verify` (394 unit tests and 32 integration tests)
- latest l12 public course API contract (59 tests)
- `docker compose config --quiet`