### PR TITLE
Add mutation testing feedback loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,14 @@
 - Default verify (CI default): `./mvnw verify`
 - Full verify with integration tests: `./mvnw -Pintegration-tests verify`
 - Tests only: `./mvnw test`
+- Targeted mutation feedback: `./mvnw -Pmutation-testing test-compile pitest:mutationCoverage`
+
+# Mutation-testing workflow
+
+- Run the normal tests first. Use the mutation profile after changing the selected authentication, cart, order, product, traffic, or LLM-handler code, or after changing their tests.
+- Treat `NO_COVERAGE` as a reachability gap and `SURVIVED` as an assertion gap. For each meaningful survivor, add a test that passes on the original code and fails on that mutant.
+- Do not optimize for the headline score by asserting implementation details or snapshotting entire objects. Classify equivalent and inconsequential mutants explicitly in the handoff.
+- Keep this targeted run advisory while the baseline is being established. In CI, reject new meaningful survivors in security, money, authorization, sanitization, and state-transition logic before introducing a repository-wide percentage gate.
 
 # Course API Contract
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>murraco</groupId>
     <artifactId>jwt-auth-service</artifactId>
-    <version>3.7.14</version>
+    <version>3.7.15</version>
     <packaging>jar</packaging>
 
     <name>spring-boot-jwt</name>
@@ -23,6 +23,8 @@
         <postgresql.version>42.7.13</postgresql.version>
         <reactor-bom.version>2025.0.6</reactor-bom.version>
         <otp-java.version>2.2.0</otp-java.version>
+        <pitest.version>1.25.8</pitest.version>
+        <pitest.junit5.version>1.2.3</pitest.junit5.version>
     </properties>
 
     <parent>
@@ -405,6 +407,61 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>mutation-testing</id>
+            <properties>
+                <skip.pmd>true</skip.pmd>
+                <skip.jacoco>true</skip.jacoco>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.pitest</groupId>
+                        <artifactId>pitest-maven</artifactId>
+                        <version>${pitest.version}</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.pitest</groupId>
+                                <artifactId>pitest-junit5-plugin</artifactId>
+                                <version>${pitest.junit5.version}</version>
+                            </dependency>
+                        </dependencies>
+                        <configuration>
+                            <targetClasses>
+                                <param>com.awesome.testing.service.ProductService</param>
+                                <param>com.awesome.testing.service.CartService</param>
+                                <param>com.awesome.testing.service.OrderService</param>
+                                <param>com.awesome.testing.service.token.RefreshTokenService</param>
+                                <param>com.awesome.testing.service.password.PasswordResetService</param>
+                                <param>com.awesome.testing.security.ratelimit.AuthRateLimitGuard</param>
+                                <param>com.awesome.testing.traffic.TrafficCapturePolicy</param>
+                                <param>com.awesome.testing.traffic.TrafficDataSanitizer</param>
+                                <param>com.awesome.testing.service.ollama.function.ProductCatalogFunctionHandler</param>
+                                <param>com.awesome.testing.service.ollama.function.ProductSnapshotFunctionHandler</param>
+                            </targetClasses>
+                            <targetTests>
+                                <param>com.awesome.testing.service.ProductServiceTest</param>
+                                <param>com.awesome.testing.service.CartServiceTest</param>
+                                <param>com.awesome.testing.service.OrderServiceTest</param>
+                                <param>com.awesome.testing.service.token.RefreshTokenServiceTest</param>
+                                <param>com.awesome.testing.service.password.PasswordResetServiceTest</param>
+                                <param>com.awesome.testing.security.ratelimit.AuthRateLimitGuardTest</param>
+                                <param>com.awesome.testing.traffic.TrafficCapturePolicyTest</param>
+                                <param>com.awesome.testing.traffic.TrafficDataSanitizerTest</param>
+                                <param>com.awesome.testing.service.ollama.function.ProductCatalogFunctionHandlerTest</param>
+                                <param>com.awesome.testing.service.ollama.function.ProductSnapshotFunctionHandlerTest</param>
+                            </targetTests>
+                            <threads>4</threads>
+                            <timestampedReports>false</timestampedReports>
+                            <outputFormats>
+                                <param>HTML</param>
+                                <param>XML</param>
+                            </outputFormats>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/src/test/java/com/awesome/testing/service/CartServiceTest.java
+++ b/src/test/java/com/awesome/testing/service/CartServiceTest.java
@@ -71,6 +71,10 @@ class CartServiceTest {
         assertThat(cart.getUsername()).isEqualTo(USERNAME);
         assertThat(cart.getTotalItems()).isEqualTo(1);
         assertThat(cart.getTotalPrice()).isEqualTo(product.getPrice());
+        assertThat(cart.getItems()).singleElement().satisfies(item -> {
+            assertThat(item.getProductId()).isEqualTo(product.getId());
+            assertThat(item.getQuantity()).isEqualTo(1);
+        });
     }
 
     @Test
@@ -100,6 +104,7 @@ class CartServiceTest {
 
     @Test
     void shouldIncreaseQuantityWhenItemAlreadyExists() {
+        product.setPrice(BigDecimal.valueOf(1250));
         CartItemDto dto = CartItemDto.builder()
                 .productId(product.getId())
                 .quantity(3)
@@ -112,8 +117,10 @@ class CartServiceTest {
         CartDto cart = cartService.addToCart(USERNAME, dto);
 
         assertThat(cartItem.getQuantity()).isEqualTo(4);
+        assertThat(cartItem.getPrice()).isEqualByComparingTo("1250");
         verify(cartItemRepository).save(cartItem);
         assertThat(cart.getTotalItems()).isEqualTo(4);
+        assertThat(cart.getTotalPrice()).isEqualByComparingTo("5000");
     }
 
     @Test
@@ -130,6 +137,7 @@ class CartServiceTest {
 
     @Test
     void shouldUpdateCartItemQuantity() {
+        product.setPrice(BigDecimal.valueOf(1250));
         UpdateCartItemDto dto = UpdateCartItemDto.builder().quantity(5).build();
         when(cartItemRepository.findByUsernameAndProductId(USERNAME, product.getId()))
                 .thenReturn(Optional.of(cartItem));
@@ -138,7 +146,9 @@ class CartServiceTest {
         CartDto cart = cartService.updateCartItem(USERNAME, product.getId(), dto);
 
         assertThat(cartItem.getQuantity()).isEqualTo(5);
+        assertThat(cartItem.getPrice()).isEqualByComparingTo("1250");
         assertThat(cart.getTotalItems()).isEqualTo(5);
+        assertThat(cart.getTotalPrice()).isEqualByComparingTo("6250");
         verify(cartItemRepository).save(cartItem);
     }
 

--- a/src/test/java/com/awesome/testing/service/ProductServiceTest.java
+++ b/src/test/java/com/awesome/testing/service/ProductServiceTest.java
@@ -3,6 +3,7 @@ package com.awesome.testing.service;
 import com.awesome.testing.controller.exception.ProductNotFoundException;
 import com.awesome.testing.dto.product.ProductCreateDto;
 import com.awesome.testing.dto.product.ProductDto;
+import com.awesome.testing.dto.product.ProductSummaryDto;
 import com.awesome.testing.dto.product.ProductUpdateDto;
 import com.awesome.testing.entity.ProductEntity;
 import com.awesome.testing.repository.ProductRepository;
@@ -124,18 +125,24 @@ class ProductServiceTest {
     @Test
     void shouldUpdateProduct() {
         ProductUpdateDto updateDto = ProductUpdateDto.builder()
+                .name("Updated laptop")
                 .description("Updated description")
                 .price(BigDecimal.valueOf(999))
                 .stockQuantity(7)
+                .category("Computers")
+                .imageUrl("https://example.com/updated-laptop.png")
                 .build();
         when(productRepository.findById(1L)).thenReturn(Optional.of(entity));
         when(productRepository.saveAndFlush(entity)).thenReturn(entity);
 
         ProductDto updated = productService.updateProduct(1L, updateDto);
 
+        assertThat(updated.getName()).isEqualTo("Updated laptop");
         assertThat(updated.getDescription()).isEqualTo("Updated description");
         assertThat(updated.getPrice()).isEqualTo(BigDecimal.valueOf(999));
         assertThat(updated.getStockQuantity()).isEqualTo(7);
+        assertThat(updated.getCategory()).isEqualTo("Computers");
+        assertThat(updated.getImageUrl()).isEqualTo("https://example.com/updated-laptop.png");
         verify(productRepository).saveAndFlush(entity);
     }
 
@@ -146,6 +153,7 @@ class ProductServiceTest {
         boolean deleted = productService.deleteProduct(1L);
 
         assertThat(deleted).isTrue();
+        verify(productRepository).delete(entity);
     }
 
     @Test
@@ -159,17 +167,27 @@ class ProductServiceTest {
 
     @Test
     void shouldListProductsWithOffsetLimit() {
+        List<ProductEntity> products = java.util.stream.LongStream.rangeClosed(1, 5)
+                .mapToObj(id -> ProductEntity.builder()
+                        .id(id)
+                        .name("Product " + id)
+                        .price(BigDecimal.TEN)
+                        .stockQuantity(1)
+                        .build())
+                .toList();
         when(productRepository.findAll(
                 org.mockito.ArgumentMatchers.<Specification<ProductEntity>>any(),
-                eq(PageRequest.of(0, 15))))
-                .thenReturn(new PageImpl<>(List.of(entity), PageRequest.of(0, 15), 1));
+                eq(PageRequest.of(0, 5))))
+                .thenReturn(new PageImpl<>(products, PageRequest.of(0, 5), 5));
 
-        var result = productService.listProducts(10, 5, null, null);
+        var result = productService.listProducts(2, 3, null, null);
 
-        assertThat(result.getProducts()).hasSize(0); // only 1 item total, offset skips it
-        assertThat(result.getTotal()).isEqualTo(1);
+        assertThat(result.getProducts())
+                .extracting(ProductSummaryDto::getId)
+                .containsExactly(3L, 4L, 5L);
+        assertThat(result.getTotal()).isEqualTo(5);
         verify(productRepository).findAll(
                 org.mockito.ArgumentMatchers.<Specification<ProductEntity>>any(),
-                eq(PageRequest.of(0, 15)));
+                eq(PageRequest.of(0, 5)));
     }
 }

--- a/src/test/java/com/awesome/testing/service/ollama/function/ProductCatalogFunctionHandlerTest.java
+++ b/src/test/java/com/awesome/testing/service/ollama/function/ProductCatalogFunctionHandlerTest.java
@@ -82,6 +82,55 @@ class ProductCatalogFunctionHandlerTest {
     }
 
     @Test
+    void shouldPreserveExplicitFalseBooleanArgument() {
+        ProductListDto listDto = ProductListDto.builder()
+                .products(List.of())
+                .total(0)
+                .page(0)
+                .size(25)
+                .build();
+        when(productService.listProducts(0, 25, null, false)).thenReturn(listDto);
+        ToolCallDto toolCall = ToolCallDto.builder()
+                .function(ToolCallFunctionDto.builder()
+                        .name("list_products")
+                        .arguments(Map.of("inStockOnly", false))
+                        .build())
+                .build();
+
+        handler.handle(toolCall);
+
+        verify(productService).listProducts(0, 25, null, false);
+    }
+
+    @Test
+    void shouldPreserveBooleanTrueAndParseStringFalse() {
+        ProductListDto listDto = ProductListDto.builder()
+                .products(List.of())
+                .total(0)
+                .page(0)
+                .size(25)
+                .build();
+        when(productService.listProducts(0, 25, null, true)).thenReturn(listDto);
+        when(productService.listProducts(0, 25, null, false)).thenReturn(listDto);
+
+        handler.handle(ToolCallDto.builder()
+                .function(ToolCallFunctionDto.builder()
+                        .name("list_products")
+                        .arguments(Map.of("inStockOnly", true))
+                        .build())
+                .build());
+        handler.handle(ToolCallDto.builder()
+                .function(ToolCallFunctionDto.builder()
+                        .name("list_products")
+                        .arguments(Map.of("inStockOnly", "false"))
+                        .build())
+                .build());
+
+        verify(productService).listProducts(0, 25, null, true);
+        verify(productService).listProducts(0, 25, null, false);
+    }
+
+    @Test
     void shouldTreatBlankCategoryAndMissingBooleanAsNull() {
         ProductListDto listDto = ProductListDto.builder()
                 .products(List.of())

--- a/src/test/java/com/awesome/testing/service/ollama/function/ProductSnapshotFunctionHandlerTest.java
+++ b/src/test/java/com/awesome/testing/service/ollama/function/ProductSnapshotFunctionHandlerTest.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -85,6 +86,14 @@ class ProductSnapshotFunctionHandlerTest {
 
         assertThat(response.getContent()).contains("error");
         assertThat(response.getContent()).contains("productId must be a number");
+    }
+
+    @Test
+    void shouldRejectBlankProductName() {
+        ChatMessageDto response = handler.handle(toolCallWithArgs(Map.of("name", "   ")));
+
+        assertThat(response.getContent()).contains("name must be provided when productId is absent");
+        verifyNoInteractions(productService);
     }
 
     private ToolCallDto toolCallWithArgs(Map<String, Object> args) {

--- a/src/test/java/com/awesome/testing/service/password/PasswordResetServiceTest.java
+++ b/src/test/java/com/awesome/testing/service/password/PasswordResetServiceTest.java
@@ -7,6 +7,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -23,9 +25,12 @@ import com.awesome.testing.repository.UserRepository;
 import com.awesome.testing.service.EmailService;
 import com.awesome.testing.service.token.PasswordResetTokenGenerator;
 import com.awesome.testing.service.token.RefreshTokenService;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -84,6 +89,7 @@ class PasswordResetServiceTest {
 
     @Test
     void shouldGenerateTokenAndSendEmailForExistingUser() {
+        Counter requestedCounter = mockMetricCounter("password.reset.requested");
         UserEntity user = sampleUser();
         when(userRepository.findByUsernameOrEmail("client", "client")).thenReturn(Optional.of(user));
         when(passwordResetTokenGenerator.generateToken()).thenReturn("raw-token");
@@ -99,6 +105,7 @@ class PasswordResetServiceTest {
         verify(passwordResetTokenRepository).deleteByUserOrExpired(eq(user), any());
         verify(passwordResetTokenRepository).save(any());
         verify(emailService).sendEmail(any(EmailDto.class), eq("email"), eq(user));
+        verify(requestedCounter).increment();
     }
 
     @Test
@@ -181,6 +188,7 @@ class PasswordResetServiceTest {
 
     @Test
     void shouldResetPasswordAndInvalidateRefreshTokens() {
+        Counter completedCounter = mockMetricCounter("password.reset.completed");
         UserEntity user = sampleUser();
 
         PasswordResetTokenEntity entity = PasswordResetTokenEntity.builder()
@@ -211,6 +219,7 @@ class PasswordResetServiceTest {
         verify(passwordResetTokenRepository).deleteAllByUser(user);
         verify(emailService).sendEmail(any(EmailDto.class), eq("email"), eq(user));
         verify(passwordResetTokenRepository, never()).save(entity);
+        verify(completedCounter).increment();
         assertThat(user.getPassword()).isEqualTo("encoded");
     }
 
@@ -310,5 +319,17 @@ class PasswordResetServiceTest {
                 .password("secret")
                 .roles(List.of(Role.ROLE_CLIENT))
                 .build();
+    }
+
+    private Counter mockMetricCounter(String metricName) {
+        MeterRegistry registry = mock(MeterRegistry.class);
+        Counter counter = mock(Counter.class);
+        doAnswer(invocation -> {
+            Consumer<MeterRegistry> action = invocation.getArgument(0);
+            action.accept(registry);
+            return null;
+        }).when(meterRegistryProvider).ifAvailable(any());
+        when(registry.counter(metricName)).thenReturn(counter);
+        return counter;
     }
 }

--- a/src/test/java/com/awesome/testing/service/token/RefreshTokenServiceTest.java
+++ b/src/test/java/com/awesome/testing/service/token/RefreshTokenServiceTest.java
@@ -63,6 +63,16 @@ class RefreshTokenServiceTest {
     }
 
     @Test
+    void shouldCreateDistinctSecureRefreshTokens() {
+        mockSavePassthrough();
+
+        IssuedRefreshToken first = refreshTokenService.createToken(user);
+        IssuedRefreshToken second = refreshTokenService.createToken(user);
+
+        assertThat(first.value()).isNotEqualTo(second.value());
+    }
+
+    @Test
     void shouldCreateUuidRefreshTokenForLegacyCompatibility() {
         mockSavePassthrough();
         ReflectionTestUtils.setField(refreshTokenService, "legacyUuidFormat", true);

--- a/src/test/java/com/awesome/testing/traffic/TrafficCapturePolicyTest.java
+++ b/src/test/java/com/awesome/testing/traffic/TrafficCapturePolicyTest.java
@@ -47,6 +47,17 @@ class TrafficCapturePolicyTest {
     }
 
     @Test
+    void shouldHonorExcludedPrefixThatAlreadyEndsWithSlash() {
+        trafficProperties.setExcludedPaths(java.util.List.of("/private/"));
+        HttpServletRequest request = mockRequest(
+                "/private/child",
+                handlerMethod(DocumentedController.class, "documentedEndpoint")
+        );
+
+        assertThat(trafficCapturePolicy.shouldCapture(request)).isFalse();
+    }
+
+    @Test
     void shouldSkipSwaggerInfrastructureEndpoints() {
         HttpServletRequest apiDocsRequest = mockRequest(
                 "/v3/api-docs",

--- a/src/test/java/com/awesome/testing/traffic/TrafficDataSanitizerTest.java
+++ b/src/test/java/com/awesome/testing/traffic/TrafficDataSanitizerTest.java
@@ -77,4 +77,31 @@ class TrafficDataSanitizerTest {
         assertThat(sanitizedBody.originalLength()).isEqualTo(16);
         assertThat(sanitizedBody.storedLength()).isEqualTo(10);
     }
+
+    @Test
+    void shouldNotTruncateBodyAtTheExactConfiguredLimit() {
+        TrafficProperties properties = new TrafficProperties();
+        properties.setMaxBodyLength(10);
+        TrafficDataSanitizer sanitizer = new TrafficDataSanitizer(properties);
+
+        TrafficBodySanitizationResult result = sanitizer.sanitizeBody("0123456789");
+
+        assertThat(result.body()).isEqualTo("0123456789");
+        assertThat(result.truncated()).isFalse();
+        assertThat(result.originalLength()).isEqualTo(10);
+        assertThat(result.storedLength()).isEqualTo(10);
+    }
+
+    @Test
+    void shouldObfuscateEmailsInNonAuthorizationHeaders() {
+        TrafficProperties properties = new TrafficProperties();
+        properties.setObfuscateEmails(true);
+        TrafficDataSanitizer sanitizer = new TrafficDataSanitizer(properties);
+
+        Map<String, List<String>> result = sanitizer.sanitizeHeaders(Map.of(
+                "X-Contact", List.of("owner@example.com", "safe-value")
+        ));
+
+        assertThat(result.get("X-Contact")).containsExactly("***", "safe-value");
+    }
 }


### PR DESCRIPTION
## What changed
- add a scoped PIT mutation-testing profile and agent workflow guidance
- strengthen service, token, traffic, password-reset, and LLM handler contracts based on surviving mutants
- bump the backend patch version to 3.7.15

## Why
Mutation feedback identified behaviors that the green unit suite executed but did not prove, including token entropy, update side effects, sanitization boundaries, metrics, and Boolean parsing combinations.

## Validation
- `./mvnw -Pfast-verify verify`
- targeted PIT run: 257 mutants, all 230 covered mutants killed (100% covered-code strength)