### PR TITLE
Sync release image and strengthen semantic contracts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - my-private-ntwk
     
   frontend:
-   image: slawekradzyminski/frontend:3.7.12@sha256:59acd367dca78a0aea8776467885eda39d56b8259906a0f110d7063e6ff7e112
+   image: slawekradzyminski/frontend:3.7.13@sha256:8f7e5cb457d277c9dd85098cb1354a646830c544d78bddca2a110ec8e1591cea
    restart: always
    ports:
      - "8081:80"

--- a/src/test/java/com/awesome/testing/security/ratelimit/AuthRateLimitGuardTest.java
+++ b/src/test/java/com/awesome/testing/security/ratelimit/AuthRateLimitGuardTest.java
@@ -132,6 +132,8 @@ class AuthRateLimitGuardTest {
                 "clientuser",
                 properties.getPolicies().getQrUser()
         );
+        verify(clientAddressResolver, never()).resolve(request);
+        verifyNoMoreInteractions(rateLimitService);
     }
 
     @Test

--- a/src/test/java/com/awesome/testing/service/password/PasswordResetServiceTest.java
+++ b/src/test/java/com/awesome/testing/service/password/PasswordResetServiceTest.java
@@ -143,6 +143,25 @@ class PasswordResetServiceTest {
     }
 
     @Test
+    void shouldAllowLocalResetWhenSsoIdentityIsIncomplete() {
+        UserEntity user = sampleUser();
+        user.setAuthProvider("keycloak");
+        when(userRepository.findByUsernameOrEmail("client", "client")).thenReturn(Optional.of(user));
+        when(passwordResetTokenGenerator.generateToken()).thenReturn("raw-token");
+        when(passwordResetTokenGenerator.hashToken("raw-token")).thenReturn("hash-token");
+        when(emailFactory.buildResetRequestEmail(any(), anyString(), any())).thenReturn(
+                EmailDto.builder().to(user.getEmail()).subject("Reset").message("Body").build()
+        );
+
+        ForgotPasswordResponseDto response = passwordResetService.requestReset(
+                "client", "127.0.0.1", "JUnit");
+
+        assertThat(response.getToken()).isEqualTo("raw-token");
+        verify(passwordResetTokenRepository).save(any());
+        verify(emailService).sendEmail(any(EmailDto.class), eq("email"), eq(user));
+    }
+
+    @Test
     void shouldBuildResetLinkFromTrustedConfiguration() {
         properties.setFrontendBaseUrl("https://shop.example/reset?source=email");
         UserEntity user = sampleUser();


### PR DESCRIPTION
## What changed
- update the development Compose frontend pin to the reviewed 3.7.13 manifest
- prove that partially migrated accounts retain local password reset
- prove authenticated email/QR rate limits never consume the anonymous IP fallback bucket

## Why
Keep local Compose aligned with the compatibility set and kill two frozen semantic mutants that survived despite 100% PIT strength for covered backend mutants.

## Validation
- focused backend tests passed
- both backend semantic mutants killed
- `docker compose config --quiet`